### PR TITLE
feat: add client to make API requests to Resend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    pull_request:
-    schedule:
-      - cron: '0 0 * * *'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,16 @@ jobs:
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }},
+          extensions: dom, mbstring, zip,
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Execute tests
+        run: vendor/bin/pest --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2]
+        php: [8.1, 8.2]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore cache directories and files.
 /.phpunit.cache
 .php-cs-fixer.cache
+.psysh.php
 
 # Mac OS X dumps these all over the place.
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # Resend PHP
 
-![Tests](https://img.shields.io/github/actions/workflow/status/jayanratna/resend-php/tests.yml?label=tests&style=for-the-badge&labelColor=000000)
-![License](https://img.shields.io/github/license/jayanratna/resend-php?color=9cf&style=for-the-badge&labelColor=000000)
+[![Tests](https://img.shields.io/github/actions/workflow/status/jayanratna/resend-php/tests.yml?label=tests&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-php/actions/workflows/tests.yml)
+[![License](https://img.shields.io/github/license/jayanratna/resend-php?color=9cf&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-php/blob/main/LICENSE)
+
+---
 
 ## Getting started
 
-Visit [Resend](https://resend.com).
+> **Requires [PHP 8.0+](https://php.net/releases/)**
+
+First, install Resend via the [Composer](https://getcomposer.org/) package manager:
+
+```bash
+composer require resend/client
+```
+
+Then, interact with Resend's API:
+
+```php
+$resend = Resend::client('re_123456789');
+
+$resend->sendEmail([
+    'from' => 'onboarding@resend.dev',
+    'to' => 'user@gmail.com',
+    'subject' => 'hello world',
+    'text' => 'it works!',
+]);
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Getting started
 
-> **Requires [PHP 8.0+](https://php.net/releases/)**
+> **Requires [PHP 8.1+](https://php.net/releases/)**
 
 First, install Resend via the [Composer](https://getcomposer.org/) package manager:
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
-        "pestphp/pest": "^1.22"
+        "pestphp/pest": "^1.22",
+        "pestphp/pest-plugin-mock": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.0",
+        "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,8 @@
 namespace Resend;
 
 use Resend\Contracts\Transporter;
+use Resend\Responses\Email\EmailSent;
+use Resend\ValueObjects\Transporter\Payload;
 
 class Client
 {
@@ -18,7 +20,12 @@ class Client
     /**
      * Send an email with the given parameters.
      */
-    public function sendEmail(array $parameters)
+    public function sendEmail(array $parameters): EmailSent
     {
+        $payload = Payload::create('email', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return EmailSent::from($result);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,6 +20,5 @@ class Client
      */
     public function sendEmail(array $parameters)
     {
-        $this->transporter->request();
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,24 @@
 
 namespace Resend;
 
+use Resend\Contracts\Transporter;
+
 class Client
 {
+    /**
+     * Create a new Client instance with the given transporter.
+     */
+    public function __construct(
+        private readonly Transporter $transporter
+    ) {
+        //
+    }
+
+    /**
+     * Send an email with the given parameters.
+     */
+    public function sendEmail(array $parameters)
+    {
+        $this->transporter->request();
+    }
 }

--- a/src/Concerns/ArrayAccessible.php
+++ b/src/Concerns/ArrayAccessible.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Resend\Concerns;
+
+use BadMethodCallException;
+
+trait ArrayAccessible
+{
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new BadMethodCallException('Cannot set response attributes.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new BadMethodCallException('Cannot unset response attributes.');
+    }
+}

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Resend\Contracts;
+
+use ArrayAccess;
+
+interface Response extends ArrayAccess
+{
+    /**
+     * Returns the array representation of the Response.
+     *
+     * @return TArray
+     */
+    public function toArray(): array;
+}

--- a/src/Contracts/Stringable.php
+++ b/src/Contracts/Stringable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Resend\Contracts;
+
+interface Stringable
+{
+    /**
+     * Returns the string representation of the object.
+     */
+    public function toString(): string;
+}

--- a/src/Contracts/Transporter.php
+++ b/src/Contracts/Transporter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Resend\Contracts;
+
+interface Transporter
+{
+    public function request();
+}

--- a/src/Contracts/Transporter.php
+++ b/src/Contracts/Transporter.php
@@ -2,7 +2,14 @@
 
 namespace Resend\Contracts;
 
+use Resend\ValueObjects\Transporter\Payload;
+
 interface Transporter
 {
-    public function request();
+    /**
+     * Sends a request to the Resend API.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function request(Payload $payload): array;
 }

--- a/src/Enums/Transporter/ContentType.php
+++ b/src/Enums/Transporter/ContentType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Resend\Enums\Transporter;
+
+enum ContentType: string
+{
+    case JSON = 'application/json';
+    case MULTIPART = 'multipart/form-data';
+}

--- a/src/Enums/Transporter/Method.php
+++ b/src/Enums/Transporter/Method.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Resend\Enums\Transporter;
+
+enum Method: string
+{
+    case GET = 'GET';
+    case POST = 'POST';
+    case PUT = 'PUT';
+    case DELETE = 'DELETE';
+}

--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Resend\Exceptions;
+
+use Exception;
+
+final class ErrorException extends Exception
+{
+    /**
+     * Creates a new Error Exception instance.
+     */
+    public function __construct(private readonly array $contents)
+    {
+        parent::__construct($contents['message']);
+    }
+}

--- a/src/Exceptions/TransporterException.php
+++ b/src/Exceptions/TransporterException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Resend\Exceptions;
+
+use Exception;
+use Psr\Http\Client\ClientExceptionInterface;
+
+final class TransporterException extends Exception
+{
+    /**
+     * Create a new Transporter exception.
+     */
+    public function __construct(ClientExceptionInterface $exception)
+    {
+        parent::__construct($exception->getMessage(), 0, $exception);
+    }
+}

--- a/src/Exceptions/UnserializableResponse.php
+++ b/src/Exceptions/UnserializableResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Resend\Exceptions;
+
+use Exception;
+use JsonException;
+
+final class UnserializableResponse extends Exception
+{
+    /**
+     * Create a new Unserializable Response exception.
+     */
+    public function __construct(JsonException $exception)
+    {
+        parent::__construct($exception->getMessage(), 0, $exception);
+    }
+}

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use Resend\Client;
 use Resend\Transporters\HttpTransporter;
 use Resend\ValueObjects\ApiKey;
+use Resend\ValueObjects\Transporter\BaseUri;
 
 final class Resend
 {
@@ -14,7 +15,7 @@ final class Resend
     {
         $apiKey = ApiKey::from($apiKey);
 
-        $baseUri = 'api.resend.com';
+        $baseUri = BaseUri::from('api.resend.com');
 
         $headers = null;
 

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -1,11 +1,27 @@
 <?php
 
+use GuzzleHttp\Client as GuzzleClient;
 use Resend\Client;
+use Resend\Transporters\HttpTransporter;
+use Resend\ValueObjects\ApiKey;
 
 final class Resend
 {
+    /**
+     * Creates a new Resend Client with the given API key.
+     */
     public static function client(string $apiKey): Client
     {
-        return new Client($apiKey);
+        $apiKey = ApiKey::from($apiKey);
+
+        $baseUri = 'api.resend.com';
+
+        $headers = null;
+
+        $client = new GuzzleClient();
+
+        $transporter = new HttpTransporter($client, $baseUri, $headers);
+
+        return new Client($transporter);
     }
 }

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -5,6 +5,7 @@ use Resend\Client;
 use Resend\Transporters\HttpTransporter;
 use Resend\ValueObjects\ApiKey;
 use Resend\ValueObjects\Transporter\BaseUri;
+use Resend\ValueObjects\Transporter\Headers;
 
 final class Resend
 {
@@ -14,13 +15,10 @@ final class Resend
     public static function client(string $apiKey): Client
     {
         $apiKey = ApiKey::from($apiKey);
-
         $baseUri = BaseUri::from('api.resend.com');
-
-        $headers = null;
+        $headers = Headers::withAuthorization($apiKey);
 
         $client = new GuzzleClient();
-
         $transporter = new HttpTransporter($client, $baseUri, $headers);
 
         return new Client($transporter);

--- a/src/Responses/Email/EmailSent.php
+++ b/src/Responses/Email/EmailSent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Resend\Responses\Email;
+
+use Resend\Concerns\ArrayAccessible;
+use Resend\Contracts\Response;
+
+final class EmailSent implements Response
+{
+    use ArrayAccessible;
+
+    public function __construct(
+        public readonly string $id,
+        public readonly string $from,
+        public readonly string $to
+    ) {
+        //
+    }
+
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['id'],
+            $attributes['from'],
+            $attributes['to']
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'from' => $this->from,
+            'to' => $this->to,
+        ];
+    }
+}

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -2,8 +2,15 @@
 
 namespace Resend\Transporters;
 
+use JsonException;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Resend\Contracts\Transporter;
+use Resend\Exceptions\TransporterException;
+use Resend\Exceptions\UnserializableResponse;
+use Resend\ValueObjects\Transporter\BaseUri;
+use Resend\ValueObjects\Transporter\Headers;
+use Resend\ValueObjects\Transporter\Payload;
 
 class HttpTransporter implements Transporter
 {
@@ -11,12 +18,35 @@ class HttpTransporter implements Transporter
      * Create a new HTTP Transporter instance.
      */
     public function __construct(
-        private readonly ClientInterface $client
+        private readonly ClientInterface $client,
+        private readonly BaseUri $baseUri,
+        private readonly Headers $headers,
     ) {
         //
     }
 
-    public function request()
+    public function request(Payload $payload): array
     {
+        $request = $payload->toRequest($this->baseUri, $this->headers);
+
+        try {
+            $response = $this->client->sendRequest($request);
+        } catch (ClientExceptionInterface $clientException) {
+            throw new TransporterException($clientException);
+        }
+
+        $contents = (string) $response->getBody();
+
+        try {
+            $response = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw new UnserializableResponse($jsonException);
+        }
+
+        if (isset($response['error'])) {
+            // TODO: Throw Error Exception
+        }
+
+        return $response;
     }
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Resend\Transporters;
+
+use Psr\Http\Client\ClientInterface;
+use Resend\Contracts\Transporter;
+
+class HttpTransporter implements Transporter
+{
+    /**
+     * Create a new HTTP Transporter instance.
+     */
+    public function __construct(
+        private readonly ClientInterface $client
+    ) {
+        //
+    }
+
+    public function request()
+    {
+    }
+}

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -6,6 +6,7 @@ use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Resend\Contracts\Transporter;
+use Resend\Exceptions\ErrorException;
 use Resend\Exceptions\TransporterException;
 use Resend\Exceptions\UnserializableResponse;
 use Resend\ValueObjects\Transporter\BaseUri;
@@ -44,7 +45,7 @@ class HttpTransporter implements Transporter
         }
 
         if (isset($response['error'])) {
-            // TODO: Throw Error Exception
+            throw new ErrorException($response['error']);
         }
 
         return $response;

--- a/src/ValueObjects/ApiKey.php
+++ b/src/ValueObjects/ApiKey.php
@@ -2,10 +2,12 @@
 
 namespace Resend\ValueObjects;
 
-final class ApiKey
+use Resend\Contracts\Stringable;
+
+final class ApiKey implements Stringable
 {
     /**
-     * Create a new API Token value object.
+     * Create a new API Key value object.
      */
     public function __construct(
         public readonly string $apiKey
@@ -13,6 +15,9 @@ final class ApiKey
         //
     }
 
+    /**
+     * Create a new API Key value object from the given API Key.
+     */
     public static function from(string $apiKey): self
     {
         return new self($apiKey);

--- a/src/ValueObjects/ApiKey.php
+++ b/src/ValueObjects/ApiKey.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Resend\ValueObjects;
+
+final class ApiKey
+{
+    /**
+     * Create a new API Token value object.
+     */
+    public function __construct(
+        public readonly string $apiKey
+    ) {
+        //
+    }
+
+    public static function from(string $apiKey): self
+    {
+        return new self($apiKey);
+    }
+
+    public function toString(): string
+    {
+        return $this->apiKey;
+    }
+}

--- a/src/ValueObjects/ResourceUri.php
+++ b/src/ValueObjects/ResourceUri.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Resend\ValueObjects;
+
+use Resend\Contracts\Stringable;
+
+final class ResourceUri implements Stringable
+{
+    /**
+     * Create a new Resource URI value object.
+     */
+    public function __construct(
+        private readonly string $uri
+    ) {
+        //
+    }
+
+    public static function create(string $resource): self
+    {
+        return new self($resource);
+    }
+
+    public function toString(): string
+    {
+        return $this->uri;
+    }
+}

--- a/src/ValueObjects/Transporter/BaseUri.php
+++ b/src/ValueObjects/Transporter/BaseUri.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Resend\ValueObjects\Transporter;
+
+use Resend\Contracts\Stringable;
+
+final class BaseUri implements Stringable
+{
+    /**
+     * Create a new Base URI value object.
+     */
+    public function __construct(
+        private readonly string $baseUri
+    ) {
+        //
+    }
+
+    /**
+     * Create a new Base URI value object from the the given URI.
+     */
+    public static function from(string $baseUri): self
+    {
+        return new self($baseUri);
+    }
+
+    public function toString(): string
+    {
+        return "https://{$this->baseUri}/";
+    }
+}

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Resend\ValueObjects\Transporter;
+
+use Resend\Enums\Transporter\ContentType;
+use Resend\ValueObjects\ApiKey;
+
+final class Headers
+{
+    /**
+     * Create a new Headers value object.
+     *
+     * @param array<string, string> $headers
+     */
+    public function __construct(
+        private readonly array $headers
+    ) {
+        //
+    }
+
+    /**
+     * Create a new Headers value object with the given API key.
+     */
+    public static function withAuthorization(ApiKey $apiKey): self
+    {
+        return new self([
+            'Authorization' => "Bearer {$apiKey->toString()}",
+        ]);
+    }
+
+    public function withContentType(ContentType $contentType, string $suffix = ''): self
+    {
+        return new self([
+            ...$this->headers,
+            'Content-Type' => $contentType->value . $suffix,
+        ]);
+    }
+
+    public function toArray(): array
+    {
+        return $this->headers;
+    }
+}

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Resend\ValueObjects\Transporter;
+
+use GuzzleHttp\Psr7\Request;
+use Resend\Enums\Transporter\ContentType;
+use Resend\Enums\Transporter\Method;
+use Resend\ValueObjects\ResourceUri;
+
+final class Payload
+{
+    public function __construct(
+        private readonly ContentType $contentType,
+        private readonly Method $method,
+        private readonly ResourceUri $uri,
+        private readonly array $parameters = []
+    ) {
+        //
+    }
+
+    public static function create(string $resource, array $parameters): self
+    {
+        $contentType = ContentType::JSON;
+        $method = Method::POST;
+        $uri = ResourceUri::create($resource);
+
+        return new self($contentType, $method, $uri, $parameters);
+    }
+
+    /**
+     * Creates a new Psr 7 Request instance.
+     */
+    public function toRequest(BaseUri $baseUri, Headers $headers): Request
+    {
+        $body = null;
+        $uri = $baseUri->toString() . $this->uri->toString();
+
+        $headers = $headers->withContentType($this->contentType);
+
+        if ($this->method === Method::POST) {
+            $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);
+        }
+
+        return new Request($this->method->value, $uri, $headers->toArray(), $body);
+    }
+}

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -1,0 +1,19 @@
+<?php
+
+use Resend\Responses\Email\EmailSent;
+
+test('send email', function () {
+    $client = mockClient('POST', 'email', [
+        'to' => 'test@resend.com',
+    ], email());
+
+    $result = $client->sendEmail([
+        'to' => 'test@resend.com',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(EmailSent::class)
+        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794')
+        ->from->toBe('onboarding@resend.dev')
+        ->to->toBe('user@gmail.com');
+});

--- a/tests/Fixtures/Email.php
+++ b/tests/Fixtures/Email.php
@@ -1,0 +1,10 @@
+<?php
+
+function email(): array
+{
+    return [
+        'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+        'from' => 'onboarding@resend.dev',
+        'to' => 'user@gmail.com',
+    ];
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,45 +1,17 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "uses()" function to bind a different classes or traits.
-|
-*/
+use Resend\Client;
+use Resend\Contracts\Transporter;
 
-// uses(Tests\TestCase::class)->in('Feature');
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-function something()
+function mockClient(string $method, string $resource, array $parameters, array|string $response, $methodName = 'request')
 {
-    // ..
+    /** @var \Mockery\MockInterface|\Resend\Contracts\Transporter $transporter */
+    $transporter = Mockery::mock(Transporter::class);
+
+    $transporter
+        ->shouldReceive($methodName)
+        ->once()
+        ->andReturn($response);
+
+    return new Client($transporter);
 }

--- a/tests/Responses/Email/EmailSent.php
+++ b/tests/Responses/Email/EmailSent.php
@@ -1,0 +1,25 @@
+<?php
+
+use Resend\Responses\Email\EmailSent;
+
+test('from', function () {
+    $email = EmailSent::from(email());
+
+    expect($email)
+        ->toBeInstanceOf(EmailSent::class)
+        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+});
+
+test('as array accessible', function () {
+    $email = EmailSent::from(email());
+
+    expect($email['id'])->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+});
+
+test('to array', function () {
+    $email = EmailSent::from(email());
+
+    expect($email->toArray())
+        ->toBeArray()
+        ->toBe(email());
+});

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -1,0 +1,45 @@
+<?php
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use Resend\Enums\Transporter\ContentType;
+use Resend\Transporters\HttpTransporter;
+use Resend\ValueObjects\ApiKey;
+use Resend\ValueObjects\Transporter\BaseUri;
+use Resend\ValueObjects\Transporter\Headers;
+use Resend\ValueObjects\Transporter\Payload;
+
+beforeEach(function () {
+    $this->client = Mockery::mock(ClientInterface::class);
+
+    $apiKey = ApiKey::from('foo');
+
+    $this->http = new HttpTransporter(
+        $this->client,
+        BaseUri::from('api.resend.com'),
+        Headers::withAuthorization($apiKey)->withContentType(ContentType::JSON)
+    );
+});
+
+test('request', function () {
+    $payload = Payload::create('email', ['to' => 'test@resend.com']);
+    $response = new Response(200, [], json_encode([
+        'foo',
+    ]));
+
+    $this->client
+         ->shouldReceive('sendRequest')
+         ->once()
+         ->withArgs(function (Request $request) {
+             expect($request->getMethod())->toBe('POST')
+                ->and($request->getUri())
+                ->getHost()->toBe('api.resend.com')
+                ->getScheme()->toBe('https')
+                ->getPath()->toBe('/email');
+
+             return true;
+         })->andReturn($response);
+
+    $this->http->request($payload);
+});

--- a/tests/ValueObjects/ApiKey.php
+++ b/tests/ValueObjects/ApiKey.php
@@ -1,0 +1,9 @@
+<?php
+
+use Resend\ValueObjects\ApiKey;
+
+it('can be created from a string', function () {
+    $apiKey = ApiKey::from('foo');
+
+    expect($apiKey->toString())->toBe('foo');
+});

--- a/tests/ValueObjects/Transporter/BaseUri.php
+++ b/tests/ValueObjects/Transporter/BaseUri.php
@@ -1,0 +1,9 @@
+<?php
+
+use Resend\ValueObjects\Transporter\BaseUri;
+
+it('can be created from a string', function () {
+    $baseUri = BaseUri::from('api.resend.com');
+
+    expect($baseUri->toString())->toBe('https://api.resend.com/');
+});

--- a/tests/ValueObjects/Transporter/Headers.php
+++ b/tests/ValueObjects/Transporter/Headers.php
@@ -1,0 +1,23 @@
+<?php
+
+use Resend\Enums\Transporter\ContentType;
+use Resend\ValueObjects\ApiKey;
+use Resend\ValueObjects\Transporter\Headers;
+
+it('can be created from an API key', function () {
+    $headers = Headers::withAuthorization(ApiKey::from('foo'));
+
+    expect($headers->toArray())->toBe([
+        'Authorization' => 'Bearer foo',
+    ]);
+});
+
+it('can have content/type', function () {
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))
+                      ->withContentType(ContentType::JSON);
+
+    expect($headers->toArray())->toBe([
+        'Authorization' => 'Bearer foo',
+        'Content-Type' => 'application/json',
+    ]);
+});

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -1,0 +1,29 @@
+<?php
+
+use Resend\Enums\Transporter\ContentType;
+use Resend\ValueObjects\ApiKey;
+use Resend\ValueObjects\Transporter\BaseUri;
+use Resend\ValueObjects\Transporter\Headers;
+use Resend\ValueObjects\Transporter\Payload;
+
+it('has a method', function () {
+    $payload = Payload::create('email', []);
+
+    $baseUri = BaseUri::from('api.resend.com');
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+
+    expect($payload->toRequest($baseUri, $headers)->getMethod())->toBe('POST');
+});
+
+it('has a body when making a POST request', function () {
+    $payload = Payload::create('email', [
+        'to' => 'test@resend.com',
+    ]);
+
+    $baseUri = BaseUri::from('api.resend.com');
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+
+    expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe(json_encode([
+        'to' => 'test@resend.com',
+    ]));
+});


### PR DESCRIPTION
This PR adds the logic in the `Client` class which is responsible for sending API requests to the Resend API.