### PR TITLE
Add `created_at` to Sent response class

### DIFF
--- a/src/Responses/Email/Sent.php
+++ b/src/Responses/Email/Sent.php
@@ -15,7 +15,8 @@ final class Sent implements Response
     public function __construct(
         public readonly string $id,
         public readonly string $from,
-        public readonly string $to
+        public readonly string $to,
+        public readonly string $createdAt
     ) {
         //
     }
@@ -28,7 +29,8 @@ final class Sent implements Response
         return new self(
             $attributes['id'],
             $attributes['from'],
-            $attributes['to']
+            $attributes['to'],
+            $attributes['created_at']
         );
     }
 
@@ -41,6 +43,7 @@ final class Sent implements Response
             'id' => $this->id,
             'from' => $this->from,
             'to' => $this->to,
+            'created_at' => $this->createdAt,
         ];
     }
 }

--- a/tests/Fixtures/Email.php
+++ b/tests/Fixtures/Email.php
@@ -6,5 +6,6 @@ function email(): array
         'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
         'from' => 'onboarding@resend.dev',
         'to' => 'user@gmail.com',
+        'created_at' => '2022-07-25T00:28:32.493138+00:00',
     ];
 }

--- a/tests/Responses/Email/Sent.php
+++ b/tests/Responses/Email/Sent.php
@@ -13,7 +13,9 @@ test('from', function () {
 test('as array accessible', function () {
     $email = Sent::from(email());
 
-    expect($email['id'])->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+    expect($email['id'])->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794')
+        ->and(isset($email['created_at']))->toBeTrue()
+        ->and($email['created_at'])->toBe('2022-07-25T00:28:32.493138+00:00');
 });
 
 test('to array', function () {


### PR DESCRIPTION
This PR adds the missing `created_at` property that would be returned by the `/email` endpoint. This is referenced from https://github.com/resendlabs/resend-openapi/blob/main/resend.yaml.

This PR also adds tests for `offsetExists`.

💯 test coverage 😉