### PR TITLE
Update package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Resend PHP
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/jayanratna/resend-php/tests.yml?label=tests&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-php/actions/workflows/tests.yml)
-[![Packagist Downloads](https://img.shields.io/packagist/dt/resend/client?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/client)
-[![Packagist Version](https://img.shields.io/packagist/v/resend/client?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/client)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/resend/resend-php?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/resend-php)
+[![Packagist Version](https://img.shields.io/packagist/v/resend/resend-php?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/resend-php)
 [![License](https://img.shields.io/github/license/jayanratna/resend-php?color=9cf&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-php/blob/main/LICENSE)
 
 ---
@@ -14,7 +14,7 @@
 First, install Resend via the [Composer](https://getcomposer.org/) package manager:
 
 ```bash
-composer require resend/client
+composer require resend/resend-php
 ```
 
 Then, interact with Resend's API:


### PR DESCRIPTION
This PR updates the package name from `resend/client` to `resend/resend-php`.