### PR TITLE
feat: Add support for new emails API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then, interact with Resend's API:
 ```php
 $resend = Resend::client('re_123456789');
 
-$resend->sendEmail([
+$resend->emails->create([
     'from' => 'onboarding@resend.dev',
     'to' => 'user@gmail.com',
     'subject' => 'hello world',

--- a/examples/email.php
+++ b/examples/email.php
@@ -9,7 +9,7 @@ $resend = Resend::client($_ENV['RESEND_API_KEY']);
 // Attempt to send out an email...
 try {
     // Send an email using plain text...
-    $result = $resend->sendEmail([
+    $result = $resend->emails->send([
         'from' => $_ENV['MAIL_FROM_ADDRESS'],
         'to' => 'user@gmail.com',
         'subject' => 'hello world',

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,13 +4,13 @@ namespace Resend;
 
 use Resend\Contracts\Transporter;
 use Resend\Service\ServiceFactory;
-use Resend\ValueObjects\Transporter\Payload;
 
 /**
  * Client used to send requests to the Resend API.
  *
  * @property \Resend\Service\ApiKey $apiKeys
  * @property \Resend\Service\Domain $domains
+ * @property \Resend\Service\Email $emails
  */
 class Client
 {
@@ -31,15 +31,12 @@ class Client
     /**
      * Send an email with the given parameters.
      *
-     * @see https://resend.com/docs/api-reference/send-email#body-parameters
+     * @deprecated
+     * @see @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
      */
     public function sendEmail(array $parameters): Email
     {
-        $payload = Payload::create('email', $parameters);
-
-        $result = $this->transporter->request($payload);
-
-        return Email::from($result);
+        return $this->emails->send($parameters);
     }
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -107,6 +107,9 @@ class Resource implements ResourceContract
         return $this->getAttributes();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function offsetExists(mixed $offset): bool
     {
         try {
@@ -116,16 +119,25 @@ class Resource implements ResourceContract
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function offsetGet(mixed $offset): mixed
     {
         return $this->getAttribute($offset);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new BadMethodCallException('Cannot set resource attributes.');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function offsetUnset(mixed $offset): void
     {
         throw new BadMethodCallException('Cannot unset resource attributes.');

--- a/src/Service/ApiKey.php
+++ b/src/Service/ApiKey.php
@@ -8,6 +8,8 @@ final class ApiKey extends Service
 {
     /**
      * Create a new API key.
+     *
+     * @see https://resend.com/docs/api-reference/api-keys/create-api-key#body-parameters
      */
     public function create(array $parameters): \Resend\ApiKey
     {
@@ -22,6 +24,8 @@ final class ApiKey extends Service
      * List all API keys.
      *
      * @return \Resend\Collection<\Resend\ApiKey>
+     *
+     * @see https://resend.com/docs/api-reference/api-keys/list-api-keys
      */
     public function list(): \Resend\Collection
     {
@@ -34,6 +38,8 @@ final class ApiKey extends Service
 
     /**
      * Remove an API key with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/api-keys/delete-api-key#path-parameters
      */
     public function remove(string $id): \Resend\ApiKey
     {

--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -8,6 +8,8 @@ final class Domain extends Service
 {
     /**
      * Add a new domain.
+     *
+     * @see https://resend.com/docs/api-reference/domains/create-domain#body-parameters
      */
     public function create(array $parameters): \Resend\Domain
     {
@@ -22,6 +24,8 @@ final class Domain extends Service
      * List all domains.
      *
      * @return \Resend\Collection<\Resend\Domain>
+     *
+     * @see https://resend.com/docs/api-reference/domains/list-domains
      */
     public function list(): \Resend\Collection
     {
@@ -34,6 +38,8 @@ final class Domain extends Service
 
     /**
      * Remove a domain with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/domains/delete-domain#path-parameters
      */
     public function remove(string $id): \Resend\Domain
     {
@@ -46,6 +52,8 @@ final class Domain extends Service
 
     /**
      * Verify a domain with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/domains/verify-domain#path-parameters
      */
     public function verify(string $id): \Resend\Domain
     {

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Resend\Service;
+
+use Resend\ValueObjects\Transporter\Payload;
+
+final class Email extends Service
+{
+    /**
+     * Retrieve an email with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/emails/retrieve-email#path-parameters
+     */
+    public function get(string $id): \Resend\Email
+    {
+        $payload = Payload::get('emails', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('emails', $result);
+    }
+
+    /**
+     * Send an email with the given parameters.
+     *
+     * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
+     */
+    public function create(array $parameters): \Resend\Email
+    {
+        $payload = Payload::create('emails', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('emails', $result);
+    }
+
+    /**
+     * Send an email with the given parameters.
+     *
+     * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
+     */
+    public function send(array $parameters): \Resend\Email
+    {
+        return $this->create($parameters);
+    }
+}

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -6,6 +6,7 @@ use Resend\ApiKey;
 use Resend\Collection;
 use Resend\Contracts\Transporter;
 use Resend\Domain;
+use Resend\Email;
 use Resend\Resource;
 
 abstract class Service
@@ -16,6 +17,7 @@ abstract class Service
     protected $mapping = [
         'api-keys' => ApiKey::class,
         'domains' => Domain::class,
+        'emails' => Email::class,
     ];
 
     /**

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -14,6 +14,7 @@ final class ServiceFactory
     private static array $classMap = [
         'apiKeys' => ApiKey::class,
         'domains' => Domain::class,
+        'emails' => Email::class,
     ];
 
     /**

--- a/src/ValueObjects/ResourceUri.php
+++ b/src/ValueObjects/ResourceUri.php
@@ -32,6 +32,14 @@ final class ResourceUri implements Stringable
     }
 
     /**
+     * Create a new Resource URI value object that retrieves the given resource.
+     */
+    public static function get(string $resource, string $id): self
+    {
+        return new self("{$resource}/{$id}");
+    }
+
+    /**
      * Create a new Resource URI value object that deletes the given resource.
      */
     public static function delete(string $resource, string $id): self

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -31,6 +31,15 @@ final class Payload
         return new self($contentType, $method, $uri);
     }
 
+    public static function get(string $resource, string $id): self
+    {
+        $contentType = ContentType::JSON;
+        $method = Method::GET;
+        $uri = ResourceUri::get($resource, $id);
+
+        return new self($contentType, $method, $uri);
+    }
+
     /**
      * Create a new Transporter Payload instance.
      */

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -4,7 +4,7 @@ use Resend\Email;
 use Resend\Service\ApiKey;
 
 test('send email', function () {
-    $client = mockClient('POST', 'email', [
+    $client = mockClient('POST', 'emails', [
         'to' => 'test@resend.com',
     ], email());
 

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -8,6 +8,7 @@ test('send email', function () {
         'to' => 'test@resend.com',
     ], email());
 
+    // Use deprecated method until it is removed...
     $result = $client->sendEmail([
         'to' => 'test@resend.com',
     ]);

--- a/tests/Fixtures/Domain.php
+++ b/tests/Fixtures/Domain.php
@@ -1,26 +1,32 @@
 <?php
 
-function apiKey(): array
+function domain(): array
 {
     return [
-        'id' => '71af5cc3-b449-4ac4-888a-5ab9f55e1dbb',
-        'name' => 'Production',
+        'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'name' => 'resend.dev',
+        'status' => 'pending',
+        'region' => 'us-east-1',
         'created_at' => '2022-07-25T00:28:32.493138+00:00',
     ];
 }
 
-function apiKeys(): array
+function domains(): array
 {
     return [
         'data' => [
             [
                 'id' => '71af5cc3-b449-4ac4-888a-5ab9f55e1dbb',
-                'name' => 'Production',
+                'name' => 'resend.dev',
+                'status' => 'pending',
+                'region' => 'us-east-1',
                 'created_at' => '2022-07-25T00:28:32.493138+00:00',
             ],
             [
                 'id' => '823ad493-7081-4344-b476-fb0db4bd1e62',
-                'name' => 'Development',
+                'name' => 'resend.com',
+                'status' => 'pending',
+                'region' => 'us-east-1',
                 'created_at' => '2022-07-25T00:28:32.493138+00:00',
             ],
         ],

--- a/tests/Service/ApiKey.php
+++ b/tests/Service/ApiKey.php
@@ -3,9 +3,9 @@
 use Resend\ApiKey;
 
 it('can delete an API key resource', function () {
-    $client = mockClient('DELETE', 'api-keys/re_123456', [], apiKey());
+    $client = mockClient('DELETE', 'api-keys/71af5cc3-b449-4ac4-888a-5ab9f55e1dbb', [], apiKey());
 
-    $result = $client->apiKeys->remove('re_123456');
+    $result = $client->apiKeys->remove('71af5cc3-b449-4ac4-888a-5ab9f55e1dbb');
 
     expect($result)->toBeInstanceOf(ApiKey::class);
 });

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -1,0 +1,43 @@
+<?php
+
+use Resend\Collection;
+use Resend\Domain;
+
+it('can create a domain resource', function () {
+    $client = mockClient('POST', 'domains', [
+        'name' => 'resend.dev',
+    ], domain());
+
+    $result = $client->domains->create([
+        'name' => 'resend.dev',
+    ]);
+
+    expect($result)->toBeInstanceOf(Domain::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});
+
+it('can get a list of domain resources', function () {
+    $client = mockClient('GET', 'domains', [], domains());
+
+    $result = $client->domains->list();
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can remove a domain resource', function () {
+    $client = mockClient('DELETE', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+
+    $result = $client->domains->remove('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+
+    expect($result)->toBeInstanceOf(Domain::class);
+});
+
+it('can verify a domain resource', function () {
+    $client = mockClient('POST', 'domains/re_1234567/verify', [], domain());
+
+    $result = $client->domains->verify('re_1234567');
+
+    expect($result)->toBeInstanceOf(Domain::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});

--- a/tests/Service/Email.php
+++ b/tests/Service/Email.php
@@ -1,0 +1,12 @@
+<?php
+
+use Resend\Email;
+
+it('can get an email resource', function () {
+    $client = mockClient('GET', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794', [], email());
+
+    $result = $client->emails->get('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+
+    expect($result)->toBeInstanceOf(Email::class)
+        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+});


### PR DESCRIPTION
This PR adds support for the new `emails` API endpoints.

- `POST` `/emails` -> `$resend->emails->create()`
- `GET` `/emails/{id}` -> `$resend->emails->get('id')`

---

This PR also deprecates the `sendEmail` method, while this method still works, it is recommended that you use the `email` service to send emails:

```php
$resend = Resend::client('re_123456789');

$resend->emails->create([...]);
// or
$resend->emails->send([...]);
```

The example has been updated to reflect the new method usage.

Resolves #19 

---

This PR also adds links in the method PHPDoc to the API documentation.