### PR TITLE
fix: add better error handling

### DIFF
--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -32,6 +32,7 @@ class Domain extends Service
         $payload = Payload::list('domains');
 
         $result = $this->transporter->request($payload);
+        var_dump($result);
 
         return $this->createResource('domains', $result);
     }

--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -32,7 +32,6 @@ class Domain extends Service
         $payload = Payload::list('domains');
 
         $result = $this->transporter->request($payload);
-        var_dump($result);
 
         return $this->createResource('domains', $result);
     }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -69,7 +69,7 @@ class HttpTransporter implements Transporter
         try {
             $response = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
 
-            $errors = ['missing_required_fields', 'missing_required_field', 'missing_api_key', 'invalid_api_key', 'invalid_from_address', 'not_found', 'method_not_allowed', 'invalid_scope', 'internal_server_error'];
+            $errors = ['missing_required_fields', 'missing_required_field', 'missing_api_key', 'invalid_api_key', 'invalid_from_address', 'validation_error', 'not_found', 'method_not_allowed', 'invalid_scope', 'internal_server_error'];
             if (
                 isset($response['error']) ||
                 in_array($response['name'], $errors)

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -69,7 +69,7 @@ class HttpTransporter implements Transporter
         try {
             $response = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
 
-            $errors = ['missing_required_fields', 'missing_required_field', 'missing_api_key', 'invalid_api_key', 'invalid_from_address', 'validation_error', 'not_found', 'method_not_allowed', 'invalid_scope', 'internal_server_error'];
+            $errors = ['missing_required_fields', 'missing_required_field', 'missing_api_key', 'invalid_api_key', 'invalid_from_address', 'validation_error', 'not_found', 'method_not_allowed', 'invalid_scope', 'restricted_api_key', 'internal_server_error'];
             if (
                 isset($response['error']) ||
                 in_array($response['name'], $errors)

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -95,6 +95,18 @@ test('request can handle serialization errors', function () {
     $this->http->request($payload);
 })->throws(UnserializableResponse::class, 'Syntax error');
 
+test('throw json errors', function () {
+    $payload = Payload::create('email', ['to' => 'test@resend.com']);
+    $response = new Response(422, [], 'err');
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andReturn($response);
+
+    $this->http->request($payload);
+})->throws(UnserializableResponse::class, 'Syntax error');
+
 test('request can handle server errors', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
     $response = new Response(422, [], json_encode([


### PR DESCRIPTION
This PR adds support for errors from the API response when an `error` object isn't present.