### PR TITLE
add support for rate limit error response

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -69,15 +69,37 @@ class HttpTransporter implements Transporter
         try {
             $response = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
 
-            $errors = ['missing_required_fields', 'missing_required_field', 'missing_api_key', 'invalid_api_key', 'invalid_from_address', 'validation_error', 'not_found', 'method_not_allowed', 'invalid_scope', 'restricted_api_key', 'internal_server_error'];
             if (
                 isset($response['error']) ||
-                in_array($response['name'], $errors)
+                $this->isResendError($response['name'])
             ) {
                 throw new ErrorException($response['error'] ?? $response);
             }
         } catch (JsonException $jsonException) {
             throw new UnserializableResponse($jsonException);
         }
+    }
+
+    /**
+     * Determine if the given error name is a Resend error.
+     */
+    protected function isResendError(string $errorName): bool
+    {
+        $errors = [
+            'missing_required_fields',
+            'missing_required_field',
+            'invalid_from_address',
+            'validation_error',
+            'missing_api_key',
+            'invalid_api_key',
+            'restricted_api_key',
+            'invalid_scope',
+            'rate_limit_exceeded',
+            'not_found',
+            'method_not_allowed',
+            'internal_server_error',
+        ];
+
+        return in_array($errorName, $errors);
     }
 }

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -95,7 +95,23 @@ test('request can handle serialization errors', function () {
     $this->http->request($payload);
 })->throws(UnserializableResponse::class, 'Syntax error');
 
-test('throw json errors', function () {
+test('request can throw resend errors', function () {
+    $payload = Payload::create('email', ['to' => 'test@resend.com']);
+    $response = new Response(422, [], json_encode([
+        'statusCode' => 422,
+        'name' => 'missing_required_field',
+        'message' => 'Missing `to` field',
+    ]));
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andReturn($response);
+
+    $this->http->request($payload);
+})->throws(ErrorException::class);
+
+test('request can throw json error', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
     $response = new Response(422, [], 'err');
 


### PR DESCRIPTION
This PR adds support for the `rate_limit_exceeded` error. This PR also moves all the Resend error name logic to a separate `isResendError` method which returns a `bool`. 

Resolves #24 