### PR TITLE
feat: add get domain by ID method

### DIFF
--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -7,6 +7,20 @@ use Resend\ValueObjects\Transporter\Payload;
 class Domain extends Service
 {
     /**
+     * Retrieve a domain with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/domains/get-domain
+     */
+    public function get(string $id): \Resend\Domain
+    {
+        $payload = Payload::get('domains', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('domains', $result);
+    }
+
+    /**
      * Add a new domain.
      *
      * @see https://resend.com/docs/api-reference/domains/create-domain#body-parameters

--- a/tests/Fixtures/Domain.php
+++ b/tests/Fixtures/Domain.php
@@ -3,6 +3,7 @@
 function domain(): array
 {
     return [
+        'object' => 'domain',
         'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
         'name' => 'resend.dev',
         'status' => 'pending',

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -3,6 +3,15 @@
 use Resend\Collection;
 use Resend\Domain;
 
+it('can get a domain resource', function () {
+    $client = mockClient('GET', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+
+    $result = $client->domains->get('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+
+    expect($result)->toBeInstanceOf(Domain::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});
+
 it('can create a domain resource', function () {
     $client = mockClient('POST', 'domains', [
         'name' => 'resend.dev',


### PR DESCRIPTION
This PR adds a `get` method to the Domain service which allows you to get a domain by `id`.