### PR TITLE
feat: add user agent header

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -18,7 +18,7 @@ class Resend
     {
         $apiKey = ApiKey::from($apiKey);
         $baseUri = BaseUri::from('api.resend.com');
-        $headers = Headers::withAuthorization($apiKey)->withUserAgent('resend-php', self::VERSION);
+        $headers = Headers::withAuthorization($apiKey);
 
         $client = new GuzzleClient();
         $transporter = new HttpTransporter($client, $baseUri, $headers);

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -9,6 +9,8 @@ use Resend\ValueObjects\Transporter\Headers;
 
 class Resend
 {
+    const VERSION = '0.7.0';
+
     /**
      * Creates a new Resend Client with the given API key.
      */
@@ -16,7 +18,7 @@ class Resend
     {
         $apiKey = ApiKey::from($apiKey);
         $baseUri = BaseUri::from('api.resend.com');
-        $headers = Headers::withAuthorization($apiKey);
+        $headers = Headers::withAuthorization($apiKey)->withUserAgent('resend-php', self::VERSION);
 
         $client = new GuzzleClient();
         $transporter = new HttpTransporter($client, $baseUri, $headers);

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -29,6 +29,17 @@ final class Headers
     }
 
     /**
+     * Create a new Headers value object with the given user agent and existing headers.
+     */
+    public function withUserAgent(string $name, string $version): self
+    {
+        return new self([
+            ...$this->headers,
+            'User-Agent' => $name . '/' . $version,
+        ]);
+    }
+
+    /**
      * Create a new Headers value object with the given content type and existing headers.
      */
     public function withContentType(ContentType $contentType, string $suffix = ''): self

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -4,6 +4,7 @@ namespace Resend\ValueObjects\Transporter;
 
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
+use Resend;
 use Resend\Enums\Transporter\ContentType;
 use Resend\Enums\Transporter\Method;
 use Resend\ValueObjects\ResourceUri;
@@ -79,7 +80,8 @@ final class Payload
 
         $uri = $baseUri->toString() . $this->uri->toString();
 
-        $headers = $headers->withContentType($this->contentType);
+        $headers = $headers->withUserAgent('resend-php', Resend::VERSION)
+            ->withContentType($this->contentType);
 
         if ($this->method === Method::POST) {
             $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -22,6 +22,7 @@ function mockClient(string $method, string $resource, array $parameters, array|s
             $request = $payload->toRequest($baseUri, $headers);
 
             return $request->getMethod() === $method
+                && $request->getHeader('User-Agent')[0] === 'resend-php/' . Resend::VERSION
                 && $request->getUri()->getPath() === "/{$resource}";
         })->andReturn($response);
 


### PR DESCRIPTION
This PR adds `User-Agent` `resend-php/{version}` header to all API requests made using the PHP SDK. This means that the `VERSION` const will need to be updated before each release is tagged.