### PR TITLE
feat: add support for 'invalid_to_address' error

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -89,6 +89,7 @@ class HttpTransporter implements Transporter
             'missing_required_fields',
             'missing_required_field',
             'invalid_from_address',
+            'invalid_to_address',
             'validation_error',
             'missing_api_key',
             'invalid_api_key',


### PR DESCRIPTION
This PR adds support for the new [`invalid_to_address`](https://resend.com/docs/api-reference/errors#invalid-to-address) error.