### PR TITLE
feat: Add the ability to override the API url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ composer.lock
 
 # Ignore cached PHPUnit results.
 .phpunit.result.cache
-
-# Ignore sample content.
-/content/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ composer.lock
 
 # Ignore cached PHPUnit results.
 .phpunit.result.cache
+
+# Ignore sample content.
+/content/

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -17,10 +17,10 @@ class Resend
     /**
      * Creates a new Resend Client with the given API key.
      */
-    public static function client(string $apiKey, $config = []): Client
+    public static function client(string $apiKey): Client
     {
         $apiKey = ApiKey::from($apiKey);
-        $baseUri = BaseUri::from(isset($config['api_base']) ? $config['api_base'] : 'api.resend.com');
+        $baseUri = BaseUri::from(getenv('RESEND_BASE_URL') ?: 'api.resend.com');
         $headers = Headers::withAuthorization($apiKey);
 
         $client = new GuzzleClient();

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -17,10 +17,10 @@ class Resend
     /**
      * Creates a new Resend Client with the given API key.
      */
-    public static function client(string $apiKey): Client
+    public static function client(string $apiKey, $config = []): Client
     {
         $apiKey = ApiKey::from($apiKey);
-        $baseUri = BaseUri::from('api.resend.com');
+        $baseUri = BaseUri::from(isset($config['api_base']) ? $config['api_base'] : 'api.resend.com');
         $headers = Headers::withAuthorization($apiKey);
 
         $client = new GuzzleClient();

--- a/src/ValueObjects/Transporter/BaseUri.php
+++ b/src/ValueObjects/Transporter/BaseUri.php
@@ -28,6 +28,12 @@ final class BaseUri implements Stringable
      */
     public function toString(): string
     {
+        foreach (['http://', 'https://'] as $protocol) {
+            if (str_starts_with($this->baseUri, $protocol)) {
+                return "{$this->baseUri}/";
+            }
+        }
+
         return "https://{$this->baseUri}/";
     }
 }

--- a/src/ValueObjects/Transporter/BaseUri.php
+++ b/src/ValueObjects/Transporter/BaseUri.php
@@ -30,7 +30,9 @@ final class BaseUri implements Stringable
     {
         foreach (['http://', 'https://'] as $protocol) {
             if (str_starts_with($this->baseUri, $protocol)) {
-                return "{$this->baseUri}/";
+                return str_ends_with($this->baseUri, '/')
+                    ? "{$this->baseUri}"
+                    : "{$this->baseUri}/";
             }
         }
 

--- a/tests/Resend.php
+++ b/tests/Resend.php
@@ -7,3 +7,11 @@ it('can create a client', function () {
 
     expect($resend)->toBeInstanceOf(Client::class);
 });
+
+it('can create a client when the RESEND_BASE_URL environment variable is set', function () {
+    putenv('RESEND_BASE_URL=https://eu-api.resend.com/');
+
+    $resend = Resend::client('foo');
+
+    expect($resend)->toBeInstanceOf(Client::class);
+});

--- a/tests/ValueObjects/Transporter/BaseUri.php
+++ b/tests/ValueObjects/Transporter/BaseUri.php
@@ -7,3 +7,9 @@ it('can be created from a string', function () {
 
     expect($baseUri->toString())->toBe('https://api.resend.com/');
 });
+
+it('can be created with a protocol', function () {
+    $baseUri = BaseUri::from('http://api.resend.test');
+
+    expect($baseUri->toString())->toBe('http://api.resend.test/');
+});

--- a/tests/ValueObjects/Transporter/BaseUri.php
+++ b/tests/ValueObjects/Transporter/BaseUri.php
@@ -13,3 +13,9 @@ it('can be created with a protocol', function () {
 
     expect($baseUri->toString())->toBe('http://api.resend.test/');
 });
+
+it('can be created with a trailing slash', function () {
+    $baseUri = BaseUri::from('https://eu-api.resend.com/');
+
+    expect($baseUri->toString())->toBe('https://eu-api.resend.com/');
+});


### PR DESCRIPTION
This PR adds the ability to define a custom API URL. This can be achieved by setting the `RESEND_BASE_URL` to the desired API URL.

The primary purpose of this is to configure the API to use the EU or testing version of Resend.