### PR TITLE
fix: add invalid_parameter error name to Resend error list

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -95,6 +95,7 @@ class HttpTransporter implements Transporter
             'invalid_api_key',
             'restricted_api_key',
             'invalid_scope',
+            'invalid_parameter',
             'rate_limit_exceeded',
             'not_found',
             'method_not_allowed',


### PR DESCRIPTION
This PR adds the `invalid_parameter` error name to the list of Resend errors. This addition will ensure the error is handled and an exception is thrown.