### PR TITLE
feat: add the ability to magically get a resource through a method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -49,6 +49,14 @@ class Client implements ClientContract
     }
 
     /**
+     * Magic method to retrieve a service by name.
+     */
+    public function __call(string $name, array $arguments)
+    {
+        return $this->getService($name);
+    }
+
+    /**
      * Attach the given API service to the client.
      */
     private function getService(string $name)

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -20,9 +20,16 @@ test('send email', function () {
         ->to->toBe('user@gmail.com');
 });
 
-test('service is created when required', function () {
+test('service is created when required through property', function () {
     $resend = Resend::client('foo');
 
     expect($resend->apiKeys)
+        ->toBeInstanceOf(ApiKey::class);
+});
+
+test('sevice is created when required through method', function () {
+    $resend = Resend::client('foo');
+
+    expect($resend->apiKeys())
         ->toBeInstanceOf(ApiKey::class);
 });


### PR DESCRIPTION
This PR adds the `__call` magic method to the `Client` class allowing developers to call a resource through a method instead of just a parameter.

Before:

```php
$resend->emails->send([...]);
```

After:

```php
// Both options are the same internally...
$resend->emails->send([...]);

$resend->emails()->send([...]);
```

Why is this useful? This allows the [`resend-laravel`](https://github.com/resendlabs/resend-laravel) package to access resources through the Facade automatically rather than having to define each resource within the Facade manually. The usage of the Laravel facade will remain the same, these changes will be internally.
