### PR TITLE
fix: reorder and add invalid_attachment error

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -86,20 +86,21 @@ class HttpTransporter implements Transporter
     protected function isResendError(string $errorName): bool
     {
         $errors = [
-            'missing_required_fields',
-            'missing_required_field',
-            'invalid_from_address',
-            'invalid_to_address',
-            'validation_error',
-            'missing_api_key',
-            'invalid_api_key',
-            'restricted_api_key',
-            'invalid_scope',
-            'invalid_parameter',
-            'rate_limit_exceeded',
-            'not_found',
-            'method_not_allowed',
             'internal_server_error',
+            'invalid_api_key',
+            'invalid_attachment',
+            'invalid_from_address',
+            'invalid_parameter',
+            'invalid_scope',
+            'invalid_to_address',
+            'method_not_allowed',
+            'missing_api_key',
+            'missing_required_field',
+            'missing_required_fields',
+            'not_found',
+            'rate_limit_exceeded',
+            'restricted_api_key',
+            'validation_error',
         ];
 
         return in_array($errorName, $errors);


### PR DESCRIPTION
This PR adds the `invalid_attachment` to ensure that the correct error is thrown when making API requests. This PR also order the Resend errors alphabetically.