### PR TITLE
feat: Add batch emails API support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-mock": "^2.0"
+        "mockery/mockery": "^1.6",
+        "pestphp/pest": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
          colors="true"
          cacheDirectory=".phpunit.cache"
+         beStrictAboutOutputDuringTests="true"
 >
     <testsuites>
         <testsuite name="default">

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use Resend\Service\ServiceFactory;
  * Client used to send requests to the Resend API.
  *
  * @property \Resend\Service\ApiKey $apiKeys
+ * @property \Resend\Service\Batch $batch
  * @property \Resend\Service\Domain $domains
  * @property \Resend\Service\Email $emails
  */

--- a/src/Service/Batch.php
+++ b/src/Service/Batch.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Resend\Service;
+
+use Resend\ValueObjects\Transporter\Payload;
+
+class Batch extends Service
+{
+    /**
+     * Send a batch of emails with the given parameters.
+     *
+     * @return \Resend\Collection<\Resend\Email>
+     *
+     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+     */
+    public function create(array $parameters): \Resend\Collection
+    {
+        $payload = Payload::create('emails/batch', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('emails', $result);
+    }
+
+    /**
+     * Send a batch of emails with the given parameters.
+     *
+     * @return \Resend\Collection<\Resend\Email>
+     *
+     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+     */
+    public function send(array $parameters): \Resend\Collection
+    {
+        return $this->create($parameters);
+    }
+}

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -43,4 +43,18 @@ class Email extends Service
     {
         return $this->create($parameters);
     }
+
+    /**
+     * Send a batch of emails with the given parameters.
+     *
+     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+     */
+    public function batch(array $parameters)
+    {
+        $payload = Payload::create('emails/batch', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('emails', $result);
+    }
 }

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -43,18 +43,4 @@ class Email extends Service
     {
         return $this->create($parameters);
     }
-
-    /**
-     * Send a batch of emails with the given parameters.
-     *
-     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
-     */
-    public function batch(array $parameters)
-    {
-        $payload = Payload::create('emails/batch', $parameters);
-
-        $result = $this->transporter->request($payload);
-
-        return $this->createResource('emails', $result);
-    }
 }

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -13,6 +13,7 @@ class ServiceFactory
      */
     private static array $classMap = [
         'apiKeys' => ApiKey::class,
+        'batch' => Batch::class,
         'domains' => Domain::class,
         'emails' => Email::class,
     ];

--- a/tests/Fixtures/Email.php
+++ b/tests/Fixtures/Email.php
@@ -9,3 +9,17 @@ function email(): array
         'created_at' => '2022-07-25T00:28:32.493138+00:00',
     ];
 }
+
+function batch(): array
+{
+    return [
+        'data' => [
+            [
+                'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+            ],
+            [
+                'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+            ],
+        ],
+    ];
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,11 +15,15 @@ function mockClient(string $method, string $resource, array $parameters, array|s
     $transporter
         ->shouldReceive($methodName)
         ->once()
-        ->withArgs(function (Payload $payload) use ($method, $resource) {
+        ->withArgs(function (Payload $payload) use ($method, $resource, $parameters) {
             $baseUri = BaseUri::from('api.resend.com');
             $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
             $request = $payload->toRequest($baseUri, $headers);
+
+            if ($method === 'POST' && (string) $request->getBody() !== json_encode($parameters)) {
+                return false;
+            }
 
             return $request->getMethod() === $method
                 && $request->getHeader('User-Agent')[0] === 'resend-php/' . Resend::VERSION

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -1,0 +1,26 @@
+<?php
+
+use Resend\Collection;
+
+it('can send a  batch of emails', function () {
+    $client = mockClient('POST', 'emails/batch', [
+        [
+            'to' => 'test@resend.com',
+        ],
+        [
+            'to' => 'test@resend.com',
+        ],
+    ], batch());
+
+    $result = $client->batch->send([
+        [
+            'to' => 'test@resend.com',
+        ],
+        [
+            'to' => 'test@resend.com',
+        ],
+    ]);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -3,23 +3,24 @@
 use Resend\Collection;
 
 it('can send a  batch of emails', function () {
-    $client = mockClient('POST', 'emails/batch', [
+    $payload = [
         [
             'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
         ],
         [
             'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
         ],
-    ], batch());
+    ];
 
-    $result = $client->batch->send([
-        [
-            'to' => 'test@resend.com',
-        ],
-        [
-            'to' => 'test@resend.com',
-        ],
-    ]);
+    $client = mockClient('POST', 'emails/batch', $payload, batch());
+
+    $result = $client->batch->send($payload);
 
     expect($result)->toBeInstanceOf(Collection::class)
         ->data->toBeArray();


### PR DESCRIPTION
This PR adds support for Batch Emails using the `batch` method in the `Email` service.

Usage:

```php
$resend = Resend::client('re_123456789');

$resend->batch->send([
  [
    'from' => 'Acme <onboarding@resend.dev>',
    'to' => ['delivered@resend.dev'],
    'subject' => 'hello world',
    'text' => 'it works!',
  ],
  [
    'from' => 'Acme <onboarding@resend.dev>',
    'to' => ['delivered@resend.dev'],
    'subject' => 'hello world',
    'text' => 'it works!',
  ],
]);

// OR

$resend->batch->create(...);
```