### PR TITLE
chore: Bump to 0.9.0

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.8.0';
+    public const VERSION = '0.9.0';
 
     /**
      * Creates a new Resend Client with the given API key.


### PR DESCRIPTION
This PR bumps the version to `0.9.0`.