### PR TITLE
feat: Add Audiences API support

### DIFF
--- a/src/Audience.php
+++ b/src/Audience.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Resend;
+
+/**
+ * @property string $id The unique identifier for the Audience.
+ * @property string $name The name of the Audience.
+ * @property string $created_at Time at which the Audience was created.
+ */
+class Audience extends Resource
+{
+    //
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use Resend\Service\ServiceFactory;
  * Client used to send requests to the Resend API.
  *
  * @property \Resend\Service\ApiKey $apiKeys
+ * @property \Resend\Service\Audience $audiences
  * @property \Resend\Service\Batch $batch
  * @property \Resend\Service\Domain $domains
  * @property \Resend\Service\Email $emails

--- a/src/Service/Audience.php
+++ b/src/Service/Audience.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Resend\Service;
+
+use Resend\ValueObjects\Transporter\Payload;
+
+class Audience extends Service
+{
+    /**
+     * Retrieve a single audience by the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/audiences/get-audience
+     */
+    public function get(string $id): \Resend\Audience
+    {
+        $payload = Payload::get('audiences', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('audiences', $result);
+    }
+
+    /**
+     * Add a new audience.
+     *
+     * @see https://resend.com/docs/api-reference/audiences/create-audience
+     */
+    public function create(array $parameters): \Resend\Audience
+    {
+        $payload = Payload::create('audiences', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('audiences', $result);
+    }
+
+    /**
+     * List all audiences.
+     *
+     * @return \Resend\Collection<\Resend\Audience>
+     *
+     * @see https://resend.com/docs/api-reference/audiences/list-audiences
+     */
+    public function list(): \Resend\Collection
+    {
+        $payload = Payload::list('audiences');
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('audiences', $result);
+    }
+
+    /**
+     * Remove a audience with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/audiences/delete-audience
+     */
+    public function remove(string $id): \Resend\Audience
+    {
+        $payload = Payload::delete('audiences', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('audiences', $result);
+    }
+}

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -3,6 +3,7 @@
 namespace Resend\Service;
 
 use Resend\ApiKey;
+use Resend\Audience;
 use Resend\Collection;
 use Resend\Contracts\Transporter;
 use Resend\Domain;
@@ -16,6 +17,7 @@ abstract class Service
      */
     protected $mapping = [
         'api-keys' => ApiKey::class,
+        'audiences' => Audience::class,
         'domains' => Domain::class,
         'emails' => Email::class,
     ];

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -13,6 +13,7 @@ class ServiceFactory
      */
     private static array $classMap = [
         'apiKeys' => ApiKey::class,
+        'audiences' => Audience::class,
         'batch' => Batch::class,
         'domains' => Domain::class,
         'emails' => Email::class,

--- a/tests/Fixtures/Audience.php
+++ b/tests/Fixtures/Audience.php
@@ -1,0 +1,26 @@
+<?php
+
+function audience(): array
+{
+    return [
+        'object' => 'audience',
+        'id' => '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        'name' => 'Registered Users',
+        'created_at' => '2023-10-06T22:59:55.977Z',
+    ];
+}
+
+function audiences(): array
+{
+    return [
+        'object' => 'list',
+        'data' => [
+            [
+                'object' => 'audience',
+                'id' => '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+                'name' => 'Registered Users',
+                'created_at' => '2023-10-06T22:59:55.977Z',
+            ],
+        ],
+    ];
+}

--- a/tests/Service/Audience.php
+++ b/tests/Service/Audience.php
@@ -1,0 +1,43 @@
+<?php
+
+use Resend\Audience;
+use Resend\Collection;
+
+it('can get a audience resource', function () {
+    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], audience());
+
+    $result = $client->audiences->get('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+
+    expect($result)->toBeInstanceOf(Audience::class)
+        ->id->toBe('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+});
+
+it('can create an audience resource', function () {
+    $client = mockClient('POST', 'audiences', [
+        'name' => 'Registered Users',
+    ], audience());
+
+    $result = $client->audiences->create([
+        'name' => 'Registered Users',
+    ]);
+
+    expect($result)->toBeInstanceOf(Audience::class)
+        ->id->toBe('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+});
+
+it('can get a list of audience resources', function () {
+    $client = mockClient('GET', 'audiences', [], audiences());
+
+    $result = $client->audiences->list();
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can remove a audience resource', function () {
+    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], audience());
+
+    $result = $client->audiences->remove('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+
+    expect($result)->toBeInstanceOf(Audience::class);
+});


### PR DESCRIPTION
This PR adds support for the Audiences API. It adds the `get`, `create`, `list`, and `remove` methods.

For example, to list all audiences, you can use:

```php
$resend = Resend::client('re_123456789');

$resend->audiences->list();
```