### PR TITLE
fix: Parameter name inconsistent

### DIFF
--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -11,9 +11,9 @@ class Contact extends Service
      *
      * @see https://resend.com/docs/api-reference/contacts/get-contact
      */
-    public function get(string $audienceId, string $contactId): \Resend\Contact
+    public function get(string $audienceId, string $id): \Resend\Contact
     {
-        $payload = Payload::get("audiences/$audienceId/contacts", $contactId);
+        $payload = Payload::get("audiences/$audienceId/contacts", $id);
 
         $result = $this->transporter->request($payload);
 

--- a/tests/Service/Contact.php
+++ b/tests/Service/Contact.php
@@ -6,7 +6,7 @@ use Resend\Contact;
 it('can get a contact in an audience', function () {
     $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], contact());
 
-    $result = $client->contacts->get('78261eea-8f8b-4381-83c6-79fa7120f1cf', 'e169aa45-1ecf-4183-9955-b1499d5701d3');
+    $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
@@ -50,7 +50,16 @@ it('can update a contact in an audience', function () {
 it('can remove a contact in an audience', function () {
     $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], contact());
 
-    $result = $client->contacts->remove('78261eea-8f8b-4381-83c6-79fa7120f1cf', 'e169aa45-1ecf-4183-9955-b1499d5701d3');
+    $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
+
+    expect($result)->toBeInstanceOf(Contact::class)
+        ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
+});
+
+it('can remove a contact in an audience using an email', function () {
+    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/acme@example.com', [], contact());
+
+    $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'acme@example.com');
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');


### PR DESCRIPTION
This PR fixes an inconsistency in the parameter name for the `get` contacts service. This PR also adds tests for removing a contact by email.