### PR TITLE
feat: Add update method to Domain service

### DIFF
--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -51,6 +51,20 @@ class Domain extends Service
     }
 
     /**
+     * Update a domain with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/domains/update-domain
+     */
+    public function update(string $id, array $parameters): \Resend\Domain
+    {
+        $payload = Payload::update('domains', $id, $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('domains', $result);
+    }
+
+    /**
      * Remove a domain with the given ID.
      *
      * @see https://resend.com/docs/api-reference/domains/delete-domain#path-parameters

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -34,6 +34,17 @@ it('can get a list of domain resources', function () {
         ->data->toBeArray();
 });
 
+it('can update a domain resource', function () {
+    $client = mockClient('PATCH', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+
+    $result = $client->domains->update('4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
+        'open_tracking' => false,
+        'click_tracking' => true,
+    ]);
+
+    expect($result)->toBeInstanceOf(Domain::class);
+});
+
 it('can remove a domain resource', function () {
     $client = mockClient('DELETE', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
 


### PR DESCRIPTION
This PR adds an `update` method to the `Domain` service, allowing you to update a domain by the given ID.