### PR TITLE
feat(Email): Add a fluent interface

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,16 @@ class Client implements ClientContract
     }
 
     /**
+     * Send an email.
+     * @param Email $email The email to send.
+     * @return \Resend\Email The sent email.
+     */
+    public function send(Email $email): \Resend\Email
+    {
+        return $this->emails->create($email->toArray());
+    }
+
+    /**
      * Send an email with the given parameters.
      *
      * @deprecated

--- a/src/Email.php
+++ b/src/Email.php
@@ -18,5 +18,101 @@ namespace Resend;
  */
 class Email extends Resource
 {
-    //
+
+    /**
+     * Add a recipient to the email.
+     * @param string $email The recipient's email address.
+     * @return $this 
+     */
+    public function to(string $email): static
+    {
+        $this->attributes['to'][] = $email;
+
+        return $this;
+    }
+
+    /**
+     * Set the sender's email address.
+     * @param string $email The sender's email address.
+     * @return $this 
+     */
+    public function sendFrom(string $email): static
+    {
+        $this->attributes['from'] = $email;
+
+        return $this;
+    }
+
+    /**
+     * Set the email subject.
+     * @param string $subject The email subject.
+     * @return $this 
+     */
+    public function subject(string $subject): static
+    {
+        $this->attributes['subject'] = $subject;
+
+        return $this;
+    }
+
+    /**
+     * Set the HTML representation of the email.
+     * @param string $html The HTML representation of the email.
+     * @return $this 
+     */
+    public function html(string $html): static
+    {
+        $this->attributes['html'] = $html;
+
+        return $this;
+    }
+
+    /**
+     * Set the text representation of the email.
+     * @param string $text The text representation of the email.
+     * @return $this 
+     */
+    public function text(string $text): static
+    {
+        $this->attributes['text'] = $text;
+
+        return $this;
+    }
+
+    /**
+     * Add a blind carbon copy recipient to the email.
+     * @param string $email The email address of the blind carbon copy recipient.
+     * @return $this 
+     */
+    public function bcc(string $email): static
+    {
+        $this->attributes['bcc'][] = $email;
+
+        return $this;
+    }
+
+    /**
+     * Add a carbon copy recipient to the email.
+     * @param string $email The email address of the carbon copy recipient.
+     * @return $this 
+     */
+    public function cc(string $email): static
+    {
+        $this->attributes['cc'][] = $email;
+
+        return $this;
+    }
+
+    /**
+     * Set the reply to email address.
+     * @param string $email The reply to email address.
+     * @return $this 
+     */
+    public function replyTo(string $email): static
+    {
+        $this->attributes['reply_to'] = $email;
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Closes #2

Hello,

I’ve worked on adding a fluent interface to simplify the process of sending emails, as suggested in issue #2. With this approach, users can now compose emails in a more intuitive and chained way, which should improve the development experience:

```php
use Resend\Email;

$resend = Resend::client('re_123456789');

$email = (new Email())
    ->to('...')
    ->sendFrom('...')
    ->subject('...')
    ->text('...');

if ($user->is_premium) {
    $email->html('...');
}

$resend->send($email);
```

I’ve implemented the methods necessary to create this fluent interface. Although I wasn't able to set up unit tests for these methods yet, I’ve confirmed they work correctly on my local machine.

Since I’m still new to the project, I don’t have full mastery of the codebase yet, so any feedback or suggestions would be greatly appreciated! Thanks so much for your patience and support.