### PR TITLE
fix: empty body requests not converted to objects

### DIFF
--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -120,7 +120,7 @@ final class Payload
             ->withContentType($this->contentType);
 
         if ($this->method === Method::POST || $this->method === Method::PATCH || $this->method === Method::PUT) {
-            $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);
+            $body = json_encode((object) $this->parameters, JSON_THROW_ON_ERROR);
         }
 
         return new Request($this->method->value, $uri, $headers->toArray(), $body);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,7 +9,7 @@ use Resend\ValueObjects\Transporter\Payload;
 
 function mockClient(string $method, string $resource, array $parameters, array|string $response, $methodName = 'request')
 {
-    /** @var \Mockery\MockInterface|\Resend\Contracts\Transporter $transporter */
+    /** @var Mockery\MockInterface|Transporter $transporter */
     $transporter = Mockery::mock(Transporter::class);
 
     $transporter
@@ -21,7 +21,10 @@ function mockClient(string $method, string $resource, array $parameters, array|s
 
             $request = $payload->toRequest($baseUri, $headers);
 
-            if ($method === 'POST' && (string) $request->getBody() !== json_encode($parameters)) {
+            if (
+                ($method === 'POST' || $method === 'PATCH' || $method === 'PUT')
+                && (string) $request->getBody() !== json_encode((object) $parameters)
+            ) {
                 return false;
             }
 

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -35,7 +35,10 @@ it('can get a list of domain resources', function () {
 });
 
 it('can update a domain resource', function () {
-    $client = mockClient('PATCH', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+    $client = mockClient('PATCH', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
+        'open_tracking' => false,
+        'click_tracking' => true,
+    ], domain());
 
     $result = $client->domains->update('4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
         'open_tracking' => false,
@@ -54,9 +57,12 @@ it('can remove a domain resource', function () {
 });
 
 it('can verify a domain resource', function () {
-    $client = mockClient('POST', 'domains/re_1234567/verify', [], domain());
+    $client = mockClient('POST', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0/verify', [], [
+        'object' => 'domain',
+        'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+    ]);
 
-    $result = $client->domains->verify('re_1234567');
+    $result = $client->domains->verify('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
 
     expect($result)->toBeInstanceOf(Domain::class)
         ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -57,6 +57,18 @@ it('can send verify requests with empty body', function () {
 
     $request = $payload->toRequest($baseUri, $headers);
 
-    expect($request->getBody()->getContents())->toBe('[]')
+    expect($request->getBody()->getContents())->toBe('{}')
         ->and($request->getUri()->getPath())->toBe('/domains/re_123456/verify');
+});
+
+it('can convert an empty array body to a JSON object', function () {
+    $payload = Payload::create('domains', []);
+
+    $baseUri = BaseUri::from('api.resend.com');
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+
+    $request = $payload->toRequest($baseUri, $headers);
+
+    expect($request->getBody()->getContents())->toBe('{}')
+        ->and($request->getUri()->getPath())->toBe('/domains');
 });


### PR DESCRIPTION
This PR fixes an issue where `POST` requests that have an empty body, such as action requests, do not get `json_encode` to an empty object. To fix this issue, now all PHP arrays that are request parameters are casted to an object before being encoded as JSON.

This PR also updates the `mockClient` in the test suite to ensure PHP arrays are properly converted to JSON.