### PR TITLE
fix: JSON encoding for request body

### DIFF
--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -120,7 +120,10 @@ final class Payload
             ->withContentType($this->contentType);
 
         if ($this->method === Method::POST || $this->method === Method::PATCH || $this->method === Method::PUT) {
-            $body = json_encode((object) $this->parameters, JSON_THROW_ON_ERROR);
+            $body = json_encode(
+                $this->parameters === [] || ! array_is_list($this->parameters) ? (object) $this->parameters : $this->parameters,
+                JSON_THROW_ON_ERROR
+            );
         }
 
         return new Request($this->method->value, $uri, $headers->toArray(), $body);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,11 +21,14 @@ function mockClient(string $method, string $resource, array $parameters, array|s
 
             $request = $payload->toRequest($baseUri, $headers);
 
-            if (
-                ($method === 'POST' || $method === 'PATCH' || $method === 'PUT')
-                && (string) $request->getBody() !== json_encode((object) $parameters)
-            ) {
-                return false;
+            if ($method === 'POST' || $method === 'PATCH' || $method === 'PUT') {
+                $expectedBody = ($parameters === [] || ! array_is_list($parameters))
+                    ? json_encode((object) $parameters, JSON_THROW_ON_ERROR)
+                    : json_encode($parameters, JSON_THROW_ON_ERROR);
+
+                if ((string) $request->getBody() !== $expectedBody) {
+                    return false;
+                }
             }
 
             return $request->getMethod() === $method

--- a/tests/Service/Broadcast.php
+++ b/tests/Service/Broadcast.php
@@ -40,6 +40,19 @@ it('can get a list of broadcast resources', function () {
         ->data->toBeArray();
 });
 
+it('can send a broadcast resource', function () {
+    $client = mockClient('POST', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/send', [
+        'scheduled_at' => 'in 1 min',
+    ], broadcast());
+
+    $result = $client->broadcasts->send('559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [
+        'scheduled_at' => 'in 1 min',
+    ]);
+
+    expect($result)->toBeInstanceOf(Broadcast::class)
+        ->id->toBe('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
+});
+
 it('can remove a broadcast resource', function () {
     $client = mockClient('DELETE', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], broadcast());
 


### PR DESCRIPTION
This PR fixes an issue in how JSON payloads are encoded. Previously all payloads were cast to an `object`, which caused sequential arrays (array of objects) to incorrectly converted into JSON objects.

Updated JSON `toRequest` method so that:

- An empty array is still cast to an empty object.
- Associative arrays are encoded to JSON objects.
- Sequential arrays remain as arrays.

Additionally this PR adds a test case for the `send` method in the Broadcasts service.

Fixes. #67 