### PR TITLE
feat: Add Idempotency-Key support

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.16.0';
+    public const VERSION = '0.17.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -25,9 +25,9 @@ class Email extends Service
      *
      * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
      */
-    public function create(array $parameters): \Resend\Email
+    public function create(array $parameters, array $options = []): \Resend\Email
     {
-        $payload = Payload::create('emails', $parameters);
+        $payload = Payload::create('emails', $parameters, $options);
 
         $result = $this->transporter->request($payload);
 
@@ -39,9 +39,9 @@ class Email extends Service
      *
      * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
      */
-    public function send(array $parameters): \Resend\Email
+    public function send(array $parameters, array $options = []): \Resend\Email
     {
-        return $this->create($parameters);
+        return $this->create($parameters, $options);
     }
 
     /**

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -106,8 +106,11 @@ class HttpTransporter implements Transporter
     {
         $errors = [
             'application_error',
+            'concurrent_idempotent_requests',
             'daily_quota_exceeded',
             'invalid_attachment',
+            'invalid_idempotency_key',
+            'invalid_idempotent_request',
             'missing_api_key',
             'missing_required_field',
             'not_found',

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -51,6 +51,17 @@ final class Headers
     }
 
     /**
+     * Create a new Headers value object with the given idempotency key and existing headers.
+     */
+    public function withIdempotencyKey(string $key): self
+    {
+        return new self([
+            ...$this->headers,
+            'Idempotency-Key' => $key,
+        ]);
+    }
+
+    /**
      * Return the headers as an array.
      */
     public function toArray(): array

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -6,7 +6,7 @@ use Resend\Service\ApiKey;
 test('send email', function () {
     $client = mockClient('POST', 'emails', [
         'to' => 'test@resend.com',
-    ], email());
+    ], [], email());
 
     // Use deprecated method until it is removed...
     $result = $client->sendEmail([

--- a/tests/Service/ApiKey.php
+++ b/tests/Service/ApiKey.php
@@ -3,7 +3,7 @@
 use Resend\ApiKey;
 
 it('can delete an API key resource', function () {
-    $client = mockClient('DELETE', 'api-keys/71af5cc3-b449-4ac4-888a-5ab9f55e1dbb', [], apiKey());
+    $client = mockClient('DELETE', 'api-keys/71af5cc3-b449-4ac4-888a-5ab9f55e1dbb', [], [], apiKey());
 
     $result = $client->apiKeys->remove('71af5cc3-b449-4ac4-888a-5ab9f55e1dbb');
 

--- a/tests/Service/Audience.php
+++ b/tests/Service/Audience.php
@@ -4,7 +4,7 @@ use Resend\Audience;
 use Resend\Collection;
 
 it('can get a audience resource', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], audience());
+    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], [], audience());
 
     $result = $client->audiences->get('78261eea-8f8b-4381-83c6-79fa7120f1cf');
 
@@ -15,7 +15,7 @@ it('can get a audience resource', function () {
 it('can create an audience resource', function () {
     $client = mockClient('POST', 'audiences', [
         'name' => 'Registered Users',
-    ], audience());
+    ], [], audience());
 
     $result = $client->audiences->create([
         'name' => 'Registered Users',
@@ -26,7 +26,7 @@ it('can create an audience resource', function () {
 });
 
 it('can get a list of audience resources', function () {
-    $client = mockClient('GET', 'audiences', [], audiences());
+    $client = mockClient('GET', 'audiences', [], [], audiences());
 
     $result = $client->audiences->list();
 
@@ -35,7 +35,7 @@ it('can get a list of audience resources', function () {
 });
 
 it('can remove a audience resource', function () {
-    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], audience());
+    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], [], audience());
 
     $result = $client->audiences->remove('78261eea-8f8b-4381-83c6-79fa7120f1cf');
 

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -18,7 +18,7 @@ it('can send a  batch of emails', function () {
         ],
     ];
 
-    $client = mockClient('POST', 'emails/batch', $payload, batch());
+    $client = mockClient('POST', 'emails/batch', $payload, [], batch());
 
     $result = $client->batch->send($payload);
 

--- a/tests/Service/Broadcast.php
+++ b/tests/Service/Broadcast.php
@@ -4,7 +4,7 @@ use Resend\Broadcast;
 use Resend\Collection;
 
 it('can get a broadcase resource', function () {
-    $client = mockClient('GET', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], broadcast());
+    $client = mockClient('GET', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], [], broadcast());
 
     $result = $client->broadcasts->get('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
 
@@ -18,7 +18,7 @@ it('can create a broadcast resource', function () {
         'from' => 'Acme <onboarding@resend.dev>',
         'subject' => 'hello world',
         'html' => 'Hi {{{FIRST_NAME|there}}}, you can unsubscribe here: {{{RESEND_UNSUBSCRIBE_URL}}}',
-    ], broadcast());
+    ], [], broadcast());
 
     $result = $client->broadcasts->create([
         'audience_id' => '78261eea-8f8b-4381-83c6-79fa7120f1cf',
@@ -32,7 +32,7 @@ it('can create a broadcast resource', function () {
 });
 
 it('can update a broadcast resource', function () {
-    $client = mockClient('PATCH', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], broadcast());
+    $client = mockClient('PATCH', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], [], broadcast());
 
     $result = $client->broadcasts->update('559ac32e-9ef5-46fb-82a1-b76b840c0f7b', []);
 
@@ -41,7 +41,7 @@ it('can update a broadcast resource', function () {
 });
 
 it('can get a list of broadcast resources', function () {
-    $client = mockClient('GET', 'broadcasts', [], broadcasts());
+    $client = mockClient('GET', 'broadcasts', [], [], broadcasts());
 
     $result = $client->broadcasts->list();
 
@@ -52,7 +52,7 @@ it('can get a list of broadcast resources', function () {
 it('can send a broadcast resource', function () {
     $client = mockClient('POST', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/send', [
         'scheduled_at' => 'in 1 min',
-    ], broadcast());
+    ], [], broadcast());
 
     $result = $client->broadcasts->send('559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [
         'scheduled_at' => 'in 1 min',
@@ -63,7 +63,7 @@ it('can send a broadcast resource', function () {
 });
 
 it('can remove a broadcast resource', function () {
-    $client = mockClient('DELETE', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], broadcast());
+    $client = mockClient('DELETE', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], [], broadcast());
 
     $result = $client->broadcasts->remove('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
 

--- a/tests/Service/Contact.php
+++ b/tests/Service/Contact.php
@@ -4,7 +4,7 @@ use Resend\Collection;
 use Resend\Contact;
 
 it('can get a contact in an audience', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], contact());
+    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
 
     $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
 
@@ -15,7 +15,7 @@ it('can get a contact in an audience', function () {
 it('can create a contact in an audience', function () {
     $client = mockClient('POST', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [
         'email' => 'steve.wozniak@gmail.com',
-    ], contact());
+    ], [], contact());
 
     $result = $client->contacts->create('78261eea-8f8b-4381-83c6-79fa7120f1cf', [
         'email' => 'steve.wozniak@gmail.com',
@@ -26,7 +26,7 @@ it('can create a contact in an audience', function () {
 });
 
 it('can get a list of contacts in an audience', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [], contacts());
+    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [], [], contacts());
 
     $result = $client->contacts->list('78261eea-8f8b-4381-83c6-79fa7120f1cf');
 
@@ -37,7 +37,7 @@ it('can get a list of contacts in an audience', function () {
 it('can update a contact in an audience', function () {
     $client = mockClient('PATCH', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [
         'first_name' => 'Steve',
-    ], contact());
+    ], [], contact());
 
     $result = $client->contacts->update('78261eea-8f8b-4381-83c6-79fa7120f1cf', 'e169aa45-1ecf-4183-9955-b1499d5701d3', [
         'first_name' => 'Steve',
@@ -48,7 +48,7 @@ it('can update a contact in an audience', function () {
 });
 
 it('can remove a contact in an audience', function () {
-    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], contact());
+    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
 
     $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
 
@@ -57,7 +57,7 @@ it('can remove a contact in an audience', function () {
 });
 
 it('can remove a contact in an audience using an email', function () {
-    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/acme@example.com', [], contact());
+    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/acme@example.com', [], [], contact());
 
     $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'acme@example.com');
 

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -4,7 +4,7 @@ use Resend\Collection;
 use Resend\Domain;
 
 it('can get a domain resource', function () {
-    $client = mockClient('GET', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+    $client = mockClient('GET', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], [], domain());
 
     $result = $client->domains->get('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
 
@@ -15,7 +15,7 @@ it('can get a domain resource', function () {
 it('can create a domain resource', function () {
     $client = mockClient('POST', 'domains', [
         'name' => 'resend.dev',
-    ], domain());
+    ], [], domain());
 
     $result = $client->domains->create([
         'name' => 'resend.dev',
@@ -26,7 +26,7 @@ it('can create a domain resource', function () {
 });
 
 it('can get a list of domain resources', function () {
-    $client = mockClient('GET', 'domains', [], domains());
+    $client = mockClient('GET', 'domains', [], [], domains());
 
     $result = $client->domains->list();
 
@@ -38,7 +38,7 @@ it('can update a domain resource', function () {
     $client = mockClient('PATCH', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
         'open_tracking' => false,
         'click_tracking' => true,
-    ], domain());
+    ], [], domain());
 
     $result = $client->domains->update('4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
         'open_tracking' => false,
@@ -49,7 +49,7 @@ it('can update a domain resource', function () {
 });
 
 it('can remove a domain resource', function () {
-    $client = mockClient('DELETE', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], domain());
+    $client = mockClient('DELETE', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], [], domain());
 
     $result = $client->domains->remove('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
 
@@ -57,7 +57,7 @@ it('can remove a domain resource', function () {
 });
 
 it('can verify a domain resource', function () {
-    $client = mockClient('POST', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0/verify', [], [
+    $client = mockClient('POST', 'domains/4dd369bc-aa82-4ff3-97de-514ae3000ee0/verify', [], [], [
         'object' => 'domain',
         'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
     ]);

--- a/tests/Service/Email.php
+++ b/tests/Service/Email.php
@@ -3,9 +3,22 @@
 use Resend\Email;
 
 it('can get an email resource', function () {
-    $client = mockClient('GET', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794', [], email());
+    $client = mockClient('GET', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794', [], [], email());
 
     $result = $client->emails->get('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+
+    expect($result)->toBeInstanceOf(Email::class)
+        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+});
+
+it('can send an email with an idempotency key', function () {
+    $client = mockClient('POST', 'emails', [
+        'to' => 'test@resend.com',
+    ], [
+        'Idempotency-Key' => 'unique-key',
+    ], email());
+
+    $result = $client->emails->send(['to' => 'test@resend.com'], ['idempotency_key' => 'unique-key']);
 
     expect($result)->toBeInstanceOf(Email::class)
         ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
@@ -14,7 +27,7 @@ it('can get an email resource', function () {
 it('can update a scheduled email', function () {
     $client = mockClient('PATCH', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794', [
         'scheduled_at' => '2024-08-05T11:52:01.858Z',
-    ], ['object' => 'email', 'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794']);
+    ], [], ['object' => 'email', 'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794']);
 
     $result = $client->emails->update('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794', [
         'scheduled_at' => '2024-08-05T11:52:01.858Z',
@@ -25,7 +38,7 @@ it('can update a scheduled email', function () {
 });
 
 it('can cancel a scheduled email', function () {
-    $client = mockClient('POST', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794/cancel', [], [
+    $client = mockClient('POST', 'emails/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794/cancel', [], [], [
         'object' => 'email',
         'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
     ]);

--- a/tests/Service/Service.php
+++ b/tests/Service/Service.php
@@ -6,7 +6,7 @@ use Resend\Collection;
 it('can create a new resource class from an API response', function () {
     $client = mockClient('POST', 'api-keys', [
         'name' => 'Production',
-    ], apiKey());
+    ], [], apiKey());
 
     $apiKeys = $client->apiKeys->create([
         'name' => 'Production',
@@ -17,7 +17,7 @@ it('can create a new resource class from an API response', function () {
 });
 
 it('can create a new collection class of resources from an API response', function () {
-    $client = mockClient('GET', 'api-keys', [], apiKeys());
+    $client = mockClient('GET', 'api-keys', [], [], apiKeys());
 
     $apiKeys = $client->apiKeys->list();
 

--- a/tests/ValueObjects/Transporter/Headers.php
+++ b/tests/ValueObjects/Transporter/Headers.php
@@ -21,3 +21,13 @@ it('can have content/type', function () {
         'Content-Type' => 'application/json',
     ]);
 });
+
+it('can have a idempotency key', function () {
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))
+        ->withIdempotencyKey('unique-key');
+
+    expect($headers->toArray())->toBe([
+        'Authorization' => 'Bearer foo',
+        'Idempotency-Key' => 'unique-key',
+    ]);
+});


### PR DESCRIPTION
This PR adds support for the `Idempotency-Key`. It can be used like:

```php
$resend->emails->send([
  'from' => 'Acme <onboarding@resend.dev>',
  'to' => ['delivered@resend.dev'],
  'subject' => 'hello world',
  'text' => 'it works!',
], [
  'idempotency_key' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794'
]);
```