### PR TITLE
feat: Add the ability to get a contact by email

### DIFF
--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -2,6 +2,7 @@
 
 namespace Resend\Service;
 
+use InvalidArgumentException;
 use Resend\ValueObjects\Transporter\Payload;
 
 class Contact extends Service
@@ -11,9 +12,15 @@ class Contact extends Service
      *
      * @see https://resend.com/docs/api-reference/contacts/get-contact
      */
-    public function get(string $audienceId, string $id): \Resend\Contact
+    public function get(string $audienceId, ?string $id = null, ?string $email = null): \Resend\Contact
     {
-        $payload = Payload::get("audiences/$audienceId/contacts", $id);
+        if (! ($id xor $email)) {
+            throw new InvalidArgumentException('You must provide either an ID or an email, but not both.');
+        }
+
+        $idOrEmail = $id ?? $email;
+
+        $payload = Payload::get("audiences/$audienceId/contacts", $idOrEmail);
 
         $result = $this->transporter->request($payload);
 

--- a/tests/Fixtures/Contact.php
+++ b/tests/Fixtures/Contact.php
@@ -5,6 +5,11 @@ function contact(): array
     return [
         'id' => 'e169aa45-1ecf-4183-9955-b1499d5701d3',
         'object' => 'contact',
+        'email' => 'steve.wozniak@gmail.com',
+        'first_name' => 'Steve',
+        'last_name' => 'Wozniak',
+        'created_at' => '2023-10-06T23:47:56.678Z',
+        'unsubscribed' => false,
     ];
 }
 
@@ -16,6 +21,11 @@ function contacts(): array
             [
                 'id' => 'e169aa45-1ecf-4183-9955-b1499d5701d3',
                 'object' => 'contact',
+                'email' => 'steve.wozniak@gmail.com',
+                'first_name' => 'Steve',
+                'last_name' => 'Wozniak',
+                'created_at' => '2023-10-06T23:47:56.678Z',
+                'unsubscribed' => false,
             ],
         ],
     ];

--- a/tests/Service/Contact.php
+++ b/tests/Service/Contact.php
@@ -1,9 +1,11 @@
 <?php
 
+use Resend\Client;
 use Resend\Collection;
 use Resend\Contact;
+use Resend\Contracts\Transporter;
 
-it('can get a contact in an audience', function () {
+it('can get a contact by id in an audience', function () {
     $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
 
     $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
@@ -11,6 +13,29 @@ it('can get a contact in an audience', function () {
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
 });
+
+it('can get a contact by email in an audience', function () {
+    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/steve.wozniak@gmail.com', [], [], contact());
+
+    $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', email: 'steve.wozniak@gmail.com');
+
+    expect($result)->toBeInstanceOf(Contact::class)
+        ->email->toBe('steve.wozniak@gmail.com');
+});
+
+it('throws an error when getting a contact by email and id in an audience', function () {
+    $transporter = Mockery::mock(Transporter::class);
+    $client = new Client($transporter);
+
+    $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3', email: 'steve.wozniak@gmail.com');
+})->throws(InvalidArgumentException::class, 'You must provide either an ID or an email, but not both.');
+
+it('throws an error when an id or email is not provided to get a contact in an audience', function () {
+    $transporter = Mockery::mock(Transporter::class);
+    $client = new Client($transporter);
+
+    $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf');
+})->throws(InvalidArgumentException::class, 'You must provide either an ID or an email, but not both.');
 
 it('can create a contact in an audience', function () {
     $client = mockClient('POST', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [


### PR DESCRIPTION
This PR adds a nicer experience to retrieve a contact by email rather than passing in an email as the `id` argument.

Before:

```php
$resend->contacts->get(audienceId: '54d81e47-9ffd-4866-86ca-64c4b081cef7',  id: 'steve.wozniak@gmail.com');
```

After:

```php
$resend->contacts->get(audienceId: '54d81e47-9ffd-4866-86ca-64c4b081cef7',  email: 'steve.wozniak@gmail.com');
```

This PR also adds an exception to the `get` method in `contacts` to ensure that you aren't passing in an `id` and an `email` together or neither, at least 1 value is required.