### PR TITLE
feat: Add Idempotency-Key support for batch emails

### DIFF
--- a/src/Service/Batch.php
+++ b/src/Service/Batch.php
@@ -13,9 +13,9 @@ class Batch extends Service
      *
      * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
      */
-    public function create(array $parameters): \Resend\Collection
+    public function create(array $parameters, array $options = []): \Resend\Collection
     {
-        $payload = Payload::create('emails/batch', $parameters);
+        $payload = Payload::create('emails/batch', $parameters, $options);
 
         $result = $this->transporter->request($payload);
 
@@ -29,8 +29,8 @@ class Batch extends Service
      *
      * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
      */
-    public function send(array $parameters): \Resend\Collection
+    public function send(array $parameters, array $options = []): \Resend\Collection
     {
-        return $this->create($parameters);
+        return $this->create($parameters, $options);
     }
 }

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -2,7 +2,7 @@
 
 use Resend\Collection;
 
-it('can send a  batch of emails', function () {
+it('can send a batch of emails', function () {
     $payload = [
         [
             'to' => 'test@resend.com',
@@ -21,6 +21,30 @@ it('can send a  batch of emails', function () {
     $client = mockClient('POST', 'emails/batch', $payload, [], batch());
 
     $result = $client->batch->send($payload);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can send a batch of emails with an idempotency key', function () {
+    $payload = [
+        [
+            'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
+        ],
+        [
+            'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
+        ],
+    ];
+
+    $client = mockClient('POST', 'emails/batch', $payload, ['Idempotency-Key' => 'unique-key'], batch());
+
+    $result = $client->batch->send($payload, ['idempotency_key' => 'unique-key']);
 
     expect($result)->toBeInstanceOf(Collection::class)
         ->data->toBeArray();


### PR DESCRIPTION
This PR adds `Idempotency-Key` support for batch emails.