### PR TITLE
fix: Robust error handling for non JSON errors

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -27,7 +27,7 @@ class ErrorException extends Exception
      */
     public function getErrorType(): string
     {
-        return $this->contents['type'];
+        return $this->contents['type'] ?? $this->contents['name'];
     }
 
     /**
@@ -35,6 +35,6 @@ class ErrorException extends Exception
      */
     public function getErrorCode(): int
     {
-        return $this->contents['code'];
+        return $this->contents['code'] ?? $this->contents['statusCode'];
     }
 }

--- a/src/Exceptions/UnserializableResponse.php
+++ b/src/Exceptions/UnserializableResponse.php
@@ -8,10 +8,24 @@ use JsonException;
 class UnserializableResponse extends Exception
 {
     /**
+     * @var string|null
+     */
+    protected $responseBody;
+
+    /**
      * Create a new Unserializable Response exception.
      */
-    public function __construct(JsonException $exception)
+    public function __construct(JsonException $exception, ?string $responseBody = null)
     {
         parent::__construct($exception->getMessage(), 0, $exception);
+        $this->responseBody = $responseBody;
+    }
+
+    /**
+     * Get the raw response body.
+     */
+    public function getResponseBody(): ?string
+    {
+        return $this->responseBody;
     }
 }

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -29,9 +29,11 @@ beforeEach(function () {
 
 test('request', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
-    $response = new Response(200, [], json_encode([
-        'foo',
-    ]));
+    $response = new Response(
+        200,
+        ['Content-Type' => 'application/json'],
+        json_encode(['foo'])
+    );
 
     $this->client
          ->shouldReceive('sendRequest')
@@ -51,10 +53,14 @@ test('request', function () {
 
 test('request response', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
-    $response = new Response(200, [], json_encode([
-        'id' => 'test_123',
-        'to' => 'test@resend.com',
-    ]));
+    $response = new Response(
+        200,
+        ['Content-Type' => 'application/json'],
+        json_encode([
+            'id' => 'test_123',
+            'to' => 'test@resend.com',
+        ])
+    );
 
     $this->client
          ->shouldReceive('sendRequest')
@@ -86,7 +92,7 @@ test('request can handle client errors', function () {
 
 test('request can handle serialization errors', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
-    $response = new Response(200, [], 'err');
+    $response = new Response(200, ['content-type' => 'text/plain'], 'err');
 
     $this->client
         ->shouldReceive('sendRequest')
@@ -94,7 +100,7 @@ test('request can handle serialization errors', function () {
         ->andReturn($response);
 
     $this->http->request($payload);
-})->throws(UnserializableResponse::class, 'Syntax error');
+})->throws(UnserializableResponse::class, "Unexpected Content-Type 'text/plain'. Response body: err");
 
 test('request can throw resend errors', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);
@@ -157,4 +163,4 @@ test('request can handle non json errors', function () {
         ->andReturn($response);
 
     $this->http->request($payload);
-})->throws(UnserializableResponse::class, 'Syntax error');
+})->throws(UnserializableResponse::class, "Unexpected Content-Type 'text/html'. Response body: err");


### PR DESCRIPTION
This PR aims to add better error handling to make it easier to diagnose and fix issues related to unexpected API responses, and avoid confusing “Syntax error” messages when the underlying problem could be a non-JSON or empty response.