### PR TITLE
feat: Add batch validation option

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.19.1';
+    public const VERSION = '0.20.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Batch.php
+++ b/src/Service/Batch.php
@@ -9,13 +9,16 @@ class Batch extends Service
     /**
      * Send a batch of emails with the given parameters.
      *
+     * @param array{'idempotency_key'?: string, 'batch_validation'?: string} $options
      * @return \Resend\Collection<\Resend\Email>
      *
-     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+     * @see https://resend.com/docs/api-reference/emails/send-batch-emails
      */
     public function create(array $parameters, array $options = []): \Resend\Collection
     {
         $payload = Payload::create('emails/batch', $parameters, $options);
+
+        $payload->withHeader('x-batch-validation', $options['batch_validation'] ?? 'strict');
 
         $result = $this->transporter->request($payload);
 
@@ -25,9 +28,10 @@ class Batch extends Service
     /**
      * Send a batch of emails with the given parameters.
      *
+     * @param array{'idempotency_key'?: string, 'batch_validation'?: string} $options
      * @return \Resend\Collection<\Resend\Email>
      *
-     * @see https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+     * @see https://resend.com/docs/api-reference/emails/send-batch-emails
      */
     public function send(array $parameters, array $options = []): \Resend\Collection
     {

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -28,6 +28,14 @@ final class Headers
         ]);
     }
 
+    public function with(string $header, string $value): self
+    {
+        return new self([
+            ...$this->headers,
+            $header => $value,
+        ]);
+    }
+
     /**
      * Create a new Headers value object with the given user agent and existing headers.
      */
@@ -58,6 +66,17 @@ final class Headers
         return new self([
             ...$this->headers,
             'Idempotency-Key' => $key,
+        ]);
+    }
+
+    /**
+     * Merge an existing set of headers with the current set of headers.
+     */
+    public function merge(Headers $headersToMerge): self
+    {
+        return new self([
+            ...$this->headers,
+            ...$headersToMerge->toArray(),
         ]);
     }
 

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -19,7 +19,7 @@ final class Payload
         private readonly Method $method,
         private readonly ResourceUri $uri,
         private readonly array $parameters = [],
-        private readonly ?string $idempotencyKey = null
+        private ?Headers $headers = null
     ) {
         //
     }
@@ -56,13 +56,13 @@ final class Payload
         $contentType = ContentType::JSON;
         $method = Method::POST;
         $uri = ResourceUri::create($resource);
-        $idempotencyKey = null;
+        $headers = new Headers([]);
 
         if (array_key_exists('idempotency_key', $options)) {
-            $idempotencyKey = $options['idempotency_key'];
+            $headers = $headers->withIdempotencyKey($options['idempotency_key']);
         }
 
-        return new self($contentType, $method, $uri, $parameters, $idempotencyKey);
+        return new self($contentType, $method, $uri, $parameters, $headers);
     }
 
     /**
@@ -114,6 +114,16 @@ final class Payload
     }
 
     /**
+     * Add the given header and value to the payload.
+     */
+    public function withHeader(string $header, string $value): self
+    {
+        $this->headers = $this->headers->with($header, $value);
+
+        return $this;
+    }
+
+    /**
      * Creates a new Psr 7 Request instance.
      */
     public function toRequest(BaseUri $baseUri, Headers $headers): RequestInterface
@@ -122,12 +132,13 @@ final class Payload
 
         $uri = $baseUri->toString() . $this->uri->toString();
 
-        $headers = $headers->withUserAgent('resend-php', Resend::VERSION)
-            ->withContentType($this->contentType);
-
-        if ($this->idempotencyKey) {
-            $headers = $headers->withIdempotencyKey($this->idempotencyKey);
+        $mergedHeaders = $headers;
+        if ($this->headers !== null) {
+            $mergedHeaders = $headers->merge($this->headers);
         }
+
+        $mergedHeaders = $mergedHeaders->withUserAgent('resend-php', Resend::VERSION)
+            ->withContentType($this->contentType);
 
         if ($this->method === Method::POST || $this->method === Method::PATCH || $this->method === Method::PUT) {
             $body = json_encode(
@@ -136,6 +147,6 @@ final class Payload
             );
         }
 
-        return new Request($this->method->value, $uri, $headers->toArray(), $body);
+        return new Request($this->method->value, $uri, $mergedHeaders->toArray(), $body);
     }
 }

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -49,3 +49,27 @@ it('can send a batch of emails with an idempotency key', function () {
     expect($result)->toBeInstanceOf(Collection::class)
         ->data->toBeArray();
 });
+
+it('can send a batch of emails with batch validation', function () {
+    $payload = [
+        [
+            'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
+        ],
+        [
+            'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
+        ],
+    ];
+
+    $client = mockClient('POST', 'emails/batch', $payload, ['x-batch-validation' => 'permissive'], batch());
+
+    $result = $client->batch->send($payload, ['batch_validation' => 'permissive']);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});


### PR DESCRIPTION
This PR adds a `batch_validation` option to the `Batch` service. This PR involves updating the internal `Payload` class to allow the use of custom headers. The `Header` class was also updated to allow merging header values into the final request.