### PR TITLE
fix: Resend client PHP doc

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -17,12 +17,9 @@ use Resend\Service\ServiceFactory;
  * @property Service\ContactProperty $contactProperties
  * @property Service\Domain $domains
  * @property Service\Email $emails
-<<<<<<< HEAD
  * @property Service\Segment $segments
-=======
  * @property Service\Template $templates
  * @property Service\Topic $topics
->>>>>>> main
  * @property Service\Webhook $webhooks
  */
 class Client implements ClientContract

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.0.1';
 
     /**
      * Creates a new Resend Client with the given API key.


### PR DESCRIPTION
This PR fixes the merge conflicts in the `Client` PHP doc. This issue simply fixes issues that would occur within a code editor.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed leftover merge conflict markers in Client.php PHPDoc to fix editor parse errors and restore accurate property hints for segments, templates, and topics. Bumped SDK version to 1.0.1.

<sup>Written for commit 8cd08c6cd54f640503f66376b9a9b74992973685. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



