### PR TITLE
chore: support PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^2.0"
+        "pestphp/pest": "^2.0|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '1.0.1';
+    public const VERSION = '1.1.0';
 
     /**
      * Creates a new Resend Client with the given API key.


### PR DESCRIPTION
This PR adds PHP 8.5 tests to the library





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PHP 8.5 to the GitHub Actions test matrix to verify compatibility and prepare for support. CI now runs against PHP 8.1–8.5, the test suite allows Pest v2–v4, and the SDK version is bumped to 1.1.0.

<sup>Written for commit 2da1bd917e36a4bd9a5b80135400c35c8880c4d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





