### PR TITLE
fix: tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,4 +45,4 @@ jobs:
         run: composer update --no-interaction --prefer-dist
 
       - name: Execute tests
-        run: vendor/bin/pest --display-deprecations --fail-on-deprecation
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^2.0|^3.0|^4.0"
+        "pestphp/pest": "^1.0|^2.0|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Architecture.php
+++ b/tests/Architecture.php
@@ -1,5 +1,8 @@
 <?php
 
-test('No debugging statements are left in the code')
-    ->expect(['var_dump'])
-    ->not->toBeUsed();
+// Only run on PEST 2.0 or higher...
+if (version_compare(Pest\version(), '2.0.0', '>=')) {
+    test('No debugging statements are left in the code')
+        ->expect(['var_dump'])
+        ->not->toBeUsed();
+}


### PR DESCRIPTION
This PR adds PEST v1 to bring back test case support for PHP 8.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Pest v1 to dev dependencies to restore PHP 8.1 test compatibility while keeping support for v2–v4. Updates CI to run vendor/bin/pest without deprecation flags and guards the Architecture test to only run on Pest >= 2.0 for v1 compatibility.

<sup>Written for commit eadc8544cff41eb1f04235f1c384b25f42e25556. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

