### PR TITLE
feat: add support for segment_id param for contacts->list

### DIFF
--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -55,14 +55,18 @@ class Contact extends Service
     /**
      * List all contacts.
      *
-     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     * @param array{'segment_id'?: string, 'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Contact>
      *
      * @see https://resend.com/docs/api-reference/contacts/list-contacts
      */
     public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list('contacts', $options);
+        $segmentId = array_key_exists('segment_id', $options) ? $options['segment_id'] : null;
+
+        $payload = $segmentId
+            ? Payload::list("segments/{$segmentId}/contacts", $options)
+            : Payload::list('contacts', $options);
 
         $result = $this->transporter->request($payload);
 

--- a/tests/Service/Contact.php
+++ b/tests/Service/Contact.php
@@ -43,6 +43,15 @@ it('can get a list of contacts', function () {
         ->data->toBeArray();
 });
 
+it('can get a list of contacts by segment_id', function () {
+    $client = mockClient('GET', 'segments/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts', [], [], contacts());
+
+    $result = $client->contacts->list(['segment_id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a']);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
 it('can update a contact by id', function () {
     $client = mockClient('PATCH', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [
         'first_name' => 'Steve',


### PR DESCRIPTION
This PR adds support for defining an optional `segment_id` option in the `contacts->list()` service.